### PR TITLE
unaligned_read_le32toh is makred as 64bit version.

### DIFF
--- a/external/hash/unaligned.h
+++ b/external/hash/unaligned.h
@@ -21,7 +21,7 @@
         (((uint16_t)(((uint8_t *)(p))[0])) <<  0) |                         \
         (((uint16_t)(((uint8_t *)(p))[1])) <<  8))
 
-#define unaligned_read_le64toh(p)  (                                        \
+#define unaligned_read_le32toh(p)  (                                        \
         (((uint32_t)(((uint8_t *)(p))[0])) <<  0) |                         \
         (((uint32_t)(((uint8_t *)(p))[1])) <<  8) |                         \
         (((uint32_t)(((uint8_t *)(p))[2])) << 16) |                         \


### PR DESCRIPTION
The unalignedread_le32toh macro is incorrectly makred as
unalignedread_le64toh and the correct 64 bit version follows afterwards.