### PR TITLE
build: Specify C language explicitly for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #cmake_minimum_required (VERSION 2.8.11)
 cmake_minimum_required (VERSION 2.8)
 
-project (FlatCC)
+project (FlatCC C)
 
 #
 # NOTE: when changing build options, clean the build using on of:


### PR DESCRIPTION
If the build system doesn't have a C++ compiler installed, CMake will fail
with a line like:
Check for working CXX compiler: CMAKE_CXX_COMPILER_FULLPATH-NOTFOUND

As flatcc is explicitly C-only, let's be sure we can use it without a C++
compiler installed.

Signed-off-by: Steve deRosier <steve.derosier@lairdtech.com>