### PR TITLE
Fixes in JSON parser

### DIFF
--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -336,12 +336,13 @@ static inline const char *flatcc_json_parser_constant_start(flatcc_json_parser_t
 static inline const char *flatcc_json_parser_object_start(flatcc_json_parser_t *ctx, const char *buf, const char *end, int *more)
 {
     if (buf == end || *buf != '{') {
+        *more = 0;
         return flatcc_json_parser_set_error(ctx, buf, end, flatcc_json_parser_error_expected_object);
     }
     buf = flatcc_json_parser_space(ctx, buf + 1, end);
     if (buf != end && *buf == '}') {
         *more = 0;
-        buf = flatcc_json_parser_space(ctx, buf + 1, end);
+        return flatcc_json_parser_space(ctx, buf + 1, end);
     }
     *more = 1;
     return buf;
@@ -381,12 +382,13 @@ static inline const char *flatcc_json_parser_object_end(flatcc_json_parser_t *ct
 static inline const char *flatcc_json_parser_array_start(flatcc_json_parser_t *ctx, const char *buf, const char *end, int *more)
 {
     if (buf == end || *buf != '[') {
+        *more = 0;
         return flatcc_json_parser_set_error(ctx, buf, end, flatcc_json_parser_error_expected_array);
     }
     buf = flatcc_json_parser_space(ctx, buf + 1, end);
     if (buf != end && *buf == ']') {
         *more = 0;
-        buf = flatcc_json_parser_space(ctx, buf + 1, end);
+        return flatcc_json_parser_space(ctx, buf + 1, end);
     }
     *more = 1;
     return buf;

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -908,6 +908,8 @@ static void gen_trie(fb_output_t *out, trie_t *trie, int a, int b, int pos)
                 n = get_dict_tag(&trie->dict[x - 1], pos, &tag, &mask, &name, &len);
                 if (n == 8) {
                     has_prefix_key = 1;
+                } else {
+                    get_dict_tag(&trie->dict[x], pos, &tag, &mask, &name, &len);
                 }
             }
             /* `x` is now the smallest key that has a suffix at pos + 8.

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -1101,9 +1101,8 @@ static int gen_global_scope_parser(fb_output_t *out)
     println(out, "{"); indent();
     if (n == 0) {
         println(out, "/* Global scope has no enum / union types to look up. */");
-        println(out, "*more = 0;");
         println(out, "return buf; /* unmatched; */");
-        println(out, "");
+        unindent(); println(out, "}");
     } else {
         println(out, "const char *unmatched = buf;");
         println(out, "const char *mark;");

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -894,7 +894,6 @@ static void gen_trie(fb_output_t *out, trie_t *trie, int a, int b, int pos)
                 gen_prefix_trie(out, trie, a, b, pos);
                 return;
             }
-            get_dict_tag(&trie->dict[x], pos, &tag, &mask, &name, &len);
             /*
              * Test for special case where prefix [pos..pos+8) is also a
              * key. We cannot branch on any tag and need a decision on
@@ -908,10 +907,9 @@ static void gen_trie(fb_output_t *out, trie_t *trie, int a, int b, int pos)
                 n = get_dict_tag(&trie->dict[x - 1], pos, &tag, &mask, &name, &len);
                 if (n == 8) {
                     has_prefix_key = 1;
-                } else {
-                    get_dict_tag(&trie->dict[x], pos, &tag, &mask, &name, &len);
                 }
             }
+            get_dict_tag(&trie->dict[x], pos, &tag, &mask, &name, &len);
             /* `x` is now the smallest key that has a suffix at pos + 8.
              * 'x - 1` may be a prefix key of [x..b]. */
             println(out, "if (w == 0x%"PRIx64") { /* prefix \"%.*s\" */",


### PR DESCRIPTION
I've started playing with flatcc with simple schemes, and found that when there are no global enums defined generated json parser is uncompilable. Then, it was unable to parse input containing empty objects or arrays ( {}, [] ). Wasn't too hard to fix :)