### PR TITLE
Added coverage target to enable coverage testing with gcov/lcov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ option(FLATCC_INSTALL "enable build of runtime library only" OFF)
 # experience issues, and this option can then help.
 option(FLATCC_TEST "enable tests" ON)
 
+# Use with debug build with testing enabled only. Enables generation
+# of coverage information during build and run. Adds target "coverage"
+# which collects data and makes HTML report in build directory
+option(FLATCC_COVERAGE "enable coverage" OFF)
+
 # Affects the flatbuffer verify operation. Normally a verify should just
 # quickly reject invalid buffers but for troubleshooting, assertions can
 # enabled. This requires rebuilding the runtime library and will likely
@@ -82,6 +87,18 @@ endif()
 
 if (FLATCC_TEST)
     enable_testing()
+endif()
+
+if (NOT FLATCC_TEST)
+    set(FLATCC_COVERAGE off)
+endif()
+
+if (NOT CMAKE_BUILD_TYPE MATCHES Debug)
+    set(FLATCC_COVERAGE off)
+endif()
+
+if (FLATCC_COVERAGE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -DNDEBUG")
 endif()
 
 if (FLATCC_DEBUG_VERIFY)
@@ -226,6 +243,12 @@ endif()
 if (FLATCC_TEST)
     add_subdirectory(test)
     add_subdirectory(samples)
+endif()
+
+if (FLATCC_COVERAGE)
+    add_custom_target(coverage
+        COMMAND lcov --capture --directory src --output-file coverage.info
+        COMMAND genhtml coverage.info --output-directory coverage)
 endif()
 
 set_target_properties(${dist_targets}

--- a/test/json_test/test_json.c
+++ b/test/json_test/test_json.c
@@ -341,5 +341,14 @@ int main()
     TEST(   "{ name: \"Monster\", testjsonprefixparsing: { aaaa: \"test\", aaaa12345: 17 } }",
             "{\"name\":\"Monster\",\"testjsonprefixparsing\":{\"aaaa\":\"test\",\"aaaa12345\":17}}" );
 
+    TEST(   "{ name: \"Monster\", testjsonprefixparsing: { bbbb: \"test\", bbbb1234: 19 } }",
+            "{\"name\":\"Monster\",\"testjsonprefixparsing\":{\"bbbb\":\"test\",\"bbbb1234\":19}}" );
+
+    TEST(   "{ name: \"Monster\", testjsonprefixparsing: { cccc: \"test\", cccc1234: 19, cccc12345: 17 } }",
+            "{\"name\":\"Monster\",\"testjsonprefixparsing\":{\"cccc\":\"test\",\"cccc1234\":19,\"cccc12345\":17}}" );
+
+    TEST(   "{ name: \"Monster\", testjsonprefixparsing: { dddd1234: 19, dddd12345: 17 } }",
+            "{\"name\":\"Monster\",\"testjsonprefixparsing\":{\"dddd1234\":19,\"dddd12345\":17}}" );
+
     return ret ? -1: 0;
 }

--- a/test/monster_test/monster_test.fbs
+++ b/test/monster_test/monster_test.fbs
@@ -54,6 +54,16 @@ table TestJSONPrefixParsing
 {
   aaaa: string;
   aaaa12345: uint;
+  
+  bbbb: string;
+  bbbb1234: long;
+  
+  cccc: string;
+  cccc1234: long;
+  cccc12345: uint;
+  
+  dddd1234: long;
+  dddd12345: uint;
 }
 
 table Monster {


### PR DESCRIPTION
Added option FLATCC_COVERAGE, which is OFF by default. It can be turned on only in debug build with tests enabled, and is useful only with gcc compiler. When turned on it enables generation of coverage information during build and run. It also adds "coverage" build target, which collects data saved during test runs and makes useful html reports. Related to #19