### PR TITLE
Quick fix for rare JSON parser cras when unexpected field encountered

### DIFF
--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -562,6 +562,7 @@ repeat_nested:
         println(out, "buf = flatcc_json_parser_string_end(ctx, buf, end);");
     } else if (is_table) {
         println(out, "buf = %s_parse_json_table(ctx, buf, end);", snref.text);
+        println(out, "if (ctx->error) return buf; /* Quick fix, should be investigated further */");
         println(out, "ref = flatcc_builder_end_table(ctx->ctx);");
     } else if (is_union) {
         println(out, "buf = flatcc_json_parser_union(ctx, buf, end, %"PRIu64", %"PRIu64", %s_parse_json_union);",


### PR DESCRIPTION
Sometimes when failing to parse table parser crashes in flatcc_builder_end_table (failing check for some frame), so I added a quick fix to early out in this case. This definitely should be investigated further, but for now I'm out of ideas, and somewhat short of time. 

As for your comment on checking for error_line instead of expected_error - I think that both checks could be useful. Anyway, if you don't like current implementation you can just drop testing commit and accept fix only. 