### PR TITLE
More tests

### DIFF
--- a/test/json_test/test_json.c
+++ b/test/json_test/test_json.c
@@ -196,15 +196,23 @@ int error_case_tests()
                 flatcc_json_parser_error_unknown_symbol );
     TEST_ERROR( "{ name: \"Monster\", test_type: Monster, test: { name: \"Joker\", colour: \"Red\" } } }",
                 flatcc_json_parser_error_unknown_symbol );
-    TEST_ERROR( "{ name: \"Monster\", test_array_of_tables: [ { nickname: \"Joker\", color: \"Red\" } ] }",
+    TEST_ERROR( "{ name: \"Monster\", testarrayoftables: [ { nickname: \"Joker\", color: \"Red\" } ] }",
                 flatcc_json_parser_error_unknown_symbol );
-    TEST_ERROR( "{ name: \"Monster\", test_array_of_tables: [ { name: \"Joker\", colour: \"Red\" } ] }",
+    TEST_ERROR( "{ name: \"Monster\", testarrayoftables: [ { name: \"Joker\", colour: \"Red\" } ] }",
                 flatcc_json_parser_error_unknown_symbol );
-    TEST_ERROR( "{ name: \"Monster\", test_array_of_tables: [ { name: \"Joker\", color: \"Red\", "
-                "test_type: Monster, test: { nickname: \"Harley\", color: \"Blue\" } } ] }",
+    TEST_ERROR( "{ name: \"Monster\", testarrayoftables: ["
+                "{ name: \"Joker\", color: \"Red\", test_type: Monster, test: { nickname: \"Harley\", color: \"Blue\" } } ] }",
                 flatcc_json_parser_error_unknown_symbol );
-    TEST_ERROR( "{ name: \"Monster\", test_array_of_tables: [ { name: \"Joker\", color: \"Red\", "
-                "test_type: Monster, test: { name: \"Harley\", colour: \"Blue\" } } ] }",
+    TEST_ERROR( "{ name: \"Monster\", testarrayoftables: ["
+                "{ name: \"Joker\", color: \"Red\", test_type: Monster, test: { name: \"Harley\", colour: \"Blue\" } } ] }",
+                flatcc_json_parser_error_unknown_symbol );
+    TEST_ERROR( "{ name: \"Monster\", testarrayoftables: ["
+                "{ name: \"Joker\", test_type: Monster, test: { nickname: \"Harley\" } },"
+                "{ name: \"Bonnie\", test_type: Monster, test: { name: \"Clyde\" } } ] }",
+                flatcc_json_parser_error_unknown_symbol );
+    TEST_ERROR( "{ name: \"Monster\", testarrayoftables: ["
+                "{ name: \"Joker\", test_type: Monster, test: { name: \"Harley\" } },"
+                "{ name: \"Bonnie\", test_type: Monster, test: { nickname: \"Clyde\" } } ] }",
                 flatcc_json_parser_error_unknown_symbol );
 
     return ret;


### PR DESCRIPTION
Actually not a lot of new tests, but fixed typos in old ones that allowed them to pass. Now these tests pass since quick fix is still in effect, but if you comment [this](https://github.com/dvidelabs/flatcc/blob/master/src/compiler/codegen_c_json_parser.c#L565) line, then test will enter endless loop starting [there](https://github.com/dvidelabs/flatcc/commit/4d82573ea2f8a927b21c85e8677074d2f033cd7a#diff-9049181caf7ad9479b155c9c554775e2R199).
