### PR TITLE
Allow to generate scan for all fields as a default option

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -249,6 +249,17 @@
 #define FLATCC_ALLOW_MULTIPLE_KEY_FIELDS 1
 #endif
 
+/*
+ * flatcc has scan functions which are equivalent to find except they
+ * don't require arrays to be sorted by field and have O(N) complexity.
+ * It makes sense to generate these functions by default for all fields,
+ * not just ones marked as key.
+ */
+
+#ifndef FLATCC_GENERATE_SCAN_FOR_ALL_FIELDS
+#define FLATCC_ALLOW_SCAN_FOR_ALL_FIELDS 1
+#endif
+
 /* flatc currently does not allow keys on structs, but it makes sense to have them. */
 #ifndef FLATCC_ALLOW_STRUCT_FIELD_KEY
 #define FLATCC_ALLOW_STRUCT_FIELD_KEY 1

--- a/config/config.h
+++ b/config/config.h
@@ -256,7 +256,7 @@
  * not just ones marked as key.
  */
 
-#ifndef FLATCC_GENERATE_SCAN_FOR_ALL_FIELDS
+#ifndef FLATCC_ALLOW_SCAN_FOR_ALL_FIELDS
 #define FLATCC_ALLOW_SCAN_FOR_ALL_FIELDS 1
 #endif
 

--- a/include/flatcc/flatcc.h
+++ b/include/flatcc/flatcc.h
@@ -33,6 +33,7 @@ struct flatcc_options {
     int allow_enum_key;
     int allow_enum_struct_field;
     int allow_multiple_key_fields;
+    int allow_scan_for_all_fields;
     int allow_string_key;
     int allow_struct_field_deprecate;
     int allow_struct_field_key;

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -885,6 +885,11 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
                 "__%sstruct_scalar_field(t, %.*s, %s%s)\n",
                 tname_ns, tname, snt.text, n, s, snt.text,
                 nsc, n, s, nsc, tname_prefix);
+            if (out->opts->allow_scan_for_all_fields || (member->metadata_flags & fb_f_key)) {
+                fprintf(out->fp,
+                        "__%sdefine_scan_by_scalar_field(%s, %.*s, %s%s)\n",
+                        nsc, snt.text, n, s, tname_ns, tname);
+            }
             if (member->metadata_flags & fb_f_key) {
                 if (already_has_key) {
                     fprintf(out->fp, "/* Note: this is not the first field with a key on this struct. */\n");
@@ -892,9 +897,6 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
                 fprintf(out->fp,     "/* Note: find only works on vectors sorted by this field. */\n");
                 fprintf(out->fp,
                         "__%sdefine_find_by_scalar_field(%s, %.*s, %s%s)\n",
-                        nsc, snt.text, n, s, tname_ns, tname);
-                fprintf(out->fp,
-                        "__%sdefine_scan_by_scalar_field(%s, %.*s, %s%s)\n",
                         nsc, snt.text, n, s, tname_ns, tname);
                 if (out->opts->cgen_sort) {
                     fprintf(out->fp,
@@ -928,6 +930,11 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
                     "__%sstruct_scalar_field(t, %.*s, %s%s)\n",
                     snref.text, snt.text, n, s, snt.text,
                     nsc, n, s, nsc, tname_prefix);
+                if (out->opts->allow_scan_for_all_fields || (member->metadata_flags & fb_f_key)) {
+                    fprintf(out->fp,
+                            "__%sdefine_scan_by_scalar_field(%s, %.*s, %s_enum_t)\n",
+                            nsc, snt.text, n, s, snref.text);
+                }
                 if (member->metadata_flags & fb_f_key) {
                     if (already_has_key) {
                         fprintf(out->fp, "/* Note: this is not the first field with a key on this table. */\n");
@@ -935,9 +942,6 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
                     fprintf(out->fp,     "/* Note: find only works on vectors sorted by this field. */\n");
                     fprintf(out->fp,
                             "__%sdefine_find_by_scalar_field(%s, %.*s, %s_enum_t)\n",
-                            nsc, snt.text, n, s, snref.text);
-                    fprintf(out->fp,
-                            "__%sdefine_scan_by_scalar_field(%s, %.*s, %s_enum_t)\n",
                             nsc, snt.text, n, s, snref.text);
                     if (out->opts->cgen_sort) {
                         fprintf(out->fp,
@@ -1225,6 +1229,11 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                 gen_panic(out, "internal error: unexpected scalar table default value");
                 continue;
             }
+            if (out->opts->allow_scan_for_all_fields || (member->metadata_flags & fb_f_key)) {
+                fprintf(out->fp,
+                        "__%sdefine_scan_by_scalar_field(%s, %.*s, %s%s)\n",
+                        nsc, snt.text, n, s, tname_ns, tname);
+            }
             if (member->metadata_flags & fb_f_key) {
                 if (already_has_key) {
                     fprintf(out->fp, "/* Note: this is not the first field with a key on this table. */\n");
@@ -1232,9 +1241,6 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                 fprintf(out->fp,     "/* Note: find only works on vectors sorted by this field. */\n");
                 fprintf(out->fp,
                         "__%sdefine_find_by_scalar_field(%s, %.*s, %s%s)\n",
-                        nsc, snt.text, n, s, tname_ns, tname);
-                fprintf(out->fp,
-                        "__%sdefine_scan_by_scalar_field(%s, %.*s, %s%s)\n",
                         nsc, snt.text, n, s, tname_ns, tname);
                 if (out->opts->cgen_sort) {
                     fprintf(out->fp,
@@ -1277,15 +1283,17 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                 "__%svector_field(%sstring_t, %llu, t, %u)\n",
                 nsc, snt.text, n, s, snt.text,
                 nsc, nsc, llu(member->id), r);
+            if (out->opts->allow_scan_for_all_fields || (member->metadata_flags & fb_f_key)) {
+                fprintf(out->fp,
+                    "__%sdefine_scan_by_string_field(%s, %.*s)\n",
+                    nsc, snt.text, n, s);
+            }
             if (member->metadata_flags & fb_f_key) {
                 if (already_has_key) {
                     fprintf(out->fp, "/* Note: this is not the first field with a key on this table. */\n");
                 }
                 fprintf(out->fp,
                     "__%sdefine_find_by_string_field(%s, %.*s)\n",
-                    nsc, snt.text, n, s);
-                fprintf(out->fp,
-                    "__%sdefine_scan_by_string_field(%s, %.*s)\n",
                     nsc, snt.text, n, s);
                 if (out->opts->cgen_sort) {
                     fprintf(out->fp,
@@ -1360,6 +1368,11 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                     gen_panic(out, "internal error: unexpected enum type referenced by table");
                     continue;
                 }
+                if (out->opts->allow_scan_for_all_fields || (member->metadata_flags & fb_f_key)) {
+                    fprintf(out->fp,
+                            "__%sdefine_scan_by_scalar_field(%s, %.*s, %s_enum_t)\n",
+                            nsc, snt.text, n, s, snref.text);
+                }
                 if (member->metadata_flags & fb_f_key) {
                     if (already_has_key) {
                         fprintf(out->fp, "/* Note: this is not the first field with a key on this table. */\n");
@@ -1367,9 +1380,6 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                     fprintf(out->fp,     "/* Note: find only works on vectors sorted by this field. */\n");
                     fprintf(out->fp,
                             "__%sdefine_find_by_scalar_field(%s, %.*s, %s_enum_t)\n",
-                            nsc, snt.text, n, s, snref.text);
-                    fprintf(out->fp,
-                            "__%sdefine_scan_by_scalar_field(%s, %.*s, %s_enum_t)\n",
                             nsc, snt.text, n, s, snref.text);
                     if (out->opts->cgen_sort) {
                         fprintf(out->fp,

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -513,10 +513,20 @@ static void gen_helpers(fb_output_t *out)
             "static inline size_t %sstring_vec_scan_ex(%sstring_vec_t vec, size_t begin, size_t end, const char *s)\n"
             "__%sscan_by_string_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s)\n"
             "static inline size_t %sstring_vec_scan_ex_n(%sstring_vec_t vec, size_t begin, size_t end, const char *s, size_t n)\n"
-            "__%sscan_by_string_n_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n",
+            "__%sscan_by_string_n_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n"
+            "static inline size_t %sstring_vec_rscan(%sstring_vec_t vec, const char *s)\n"
+            "__%srscan_by_string_field(0, %sstring_vec_len(vec), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s)\n"
+            "static inline size_t %sstring_vec_rscan_n(%sstring_vec_t vec, const char *s, size_t n)\n"
+            "__%srscan_by_string_n_field(0, %sstring_vec_len(vec), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n"
+            "static inline size_t %sstring_vec_rscan_ex(%sstring_vec_t vec, size_t begin, size_t end, const char *s)\n"
+            "__%srscan_by_string_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s)\n"
+            "static inline size_t %sstring_vec_rscan_ex_n(%sstring_vec_t vec, size_t begin, size_t end, const char *s, size_t n)\n"
+            "__%srscan_by_string_n_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n",
             nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc,
             nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc,
-            nsc, nsc);
+            nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc,
+            nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc,
+            nsc, nsc, nsc, nsc);
     if (out->opts->cgen_sort) {
         fprintf(out->fp, "__%sdefine_string_sort()\n", nsc);
     }

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -80,9 +80,10 @@ static void gen_find(fb_output_t *out)
     fprintf(out->fp,
         "#include <string.h>\n"
         "static size_t %snot_found = (size_t)-1;\n"
+        "static size_t %send = (size_t)-1;\n"
         "#define __%sidentity(n) (n)\n"
         "#define __%smin(a, b) ((a) < (b) ? (a) : (b))\n",
-        nsc, nsc, nsc);
+        nsc, nsc, nsc, nsc);
     fprintf(out->fp,
         "/* Subtraction doesn't work for unsigned types. */\n"
         "#define __%sscalar_cmp(x, y, n) ((x) < (y) ? -1 : (x) > (y))\n"
@@ -201,43 +202,33 @@ static void gen_scan(fb_output_t *out)
         "#define __%sdefine_scan_by_scalar_field(N, NK, TK)\\\n"
         "static inline size_t N ## _vec_scan_by_ ## NK(N ## _vec_t vec, TK key)\\\n"
         "__%sscan_by_scalar_field(0, N ## _vec_len(vec), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, key, TK)\\\n"
-        "static inline size_t N ## _vec_scan_from_by_ ## NK(N ## _vec_t vec, size_t pos, TK key)\\\n"
-        "__%sscan_by_scalar_field(pos, N ## _vec_len(vec), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, key, TK)\\\n"
-        "static inline size_t N ## _vec_scan_range_by_ ## NK(N ## _vec_t vec, size_t begin, size_t end, TK key)\\\n"
+        "static inline size_t N ## _vec_scan_ex_by_ ## NK(N ## _vec_t vec, size_t begin, size_t end, TK key)\\\n"
         "__%sscan_by_scalar_field(begin, __%smin(end, N ## _vec_len(vec)), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, key, TK)\n",
-        nsc, nsc, nsc, nsc, nsc);
+        nsc, nsc, nsc, nsc);
     fprintf(out->fp,
         "#define __%sdefine_scalar_scan(N, T)\\\n"
         "static inline size_t N ## _vec_scan(N ## _vec_t vec, T key)\\\n"
         "__%sscan_by_scalar_field(0, N ## _vec_len(vec), __%sidentity, vec, N ## _vec_at, N ## _vec_len, key, T)\\\n"
-        "static inline size_t N ## _vec_scan_from(N ## _vec_t vec, size_t pos, T key)\\\n"
-        "__%sscan_by_scalar_field(pos, N ## _vec_len(vec), __%sidentity, vec, N ## _vec_at, N ## _vec_len, key, T)\\\n"
-        "static inline size_t N ## _vec_scan_range(N ## _vec_t vec, size_t begin, size_t end, T key)\\\n"
+        "static inline size_t N ## _vec_scan_ex(N ## _vec_t vec, size_t begin, size_t end, T key)\\\n"
         "__%sscan_by_scalar_field(begin, __%smin(end, N ## _vec_len(vec)), __%sidentity, vec, N ## _vec_at, N ## _vec_len, key, T)\n",
-        nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc);
+        nsc, nsc, nsc, nsc, nsc, nsc);
     fprintf(out->fp,
         "#define __%sdefine_scan_by_string_field(N, NK) \\\n"
         "static inline size_t N ## _vec_scan_by_ ## NK(N ## _vec_t vec, const char *s)\\\n"
         "__%sscan_by_string_field(0, N ## _vec_len(vec), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, s)\\\n"
         "static inline size_t N ## _vec_scan_n_by_ ## NK(N ## _vec_t vec, const char *s, int n)\\\n"
         "__%sscan_by_string_n_field(0, N ## _vec_len(vec), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, s, n)\\\n"
-        "static inline size_t N ## _vec_scan_from_by_ ## NK(N ## _vec_t vec, size_t pos, const char *s)\\\n"
-        "__%sscan_by_string_field(pos, N ## _vec_len(vec), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, s)\\\n"
-        "static inline size_t N ## _vec_scan_n_from_by_ ## NK(N ## _vec_t vec, size_t pos, const char *s, int n)\\\n"
-        "__%sscan_by_string_n_field(pos, N ## _vec_len(vec), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, s, n)\\\n"
-        "static inline size_t N ## _vec_scan_range_by_ ## NK(N ## _vec_t vec, size_t begin, size_t end, const char *s)\\\n"
+        "static inline size_t N ## _vec_scan_ex_by_ ## NK(N ## _vec_t vec, size_t begin, size_t end, const char *s)\\\n"
         "__%sscan_by_string_field(begin, __%smin(end, N ## _vec_len(vec)), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, s)\\\n"
-        "static inline size_t N ## _vec_scan_n_range_by_ ## NK(N ## _vec_t vec, size_t begin, size_t end, const char *s, int n)\\\n"
+        "static inline size_t N ## _vec_scan_ex_n_by_ ## NK(N ## _vec_t vec, size_t begin, size_t end, const char *s, int n)\\\n"
         "__%sscan_by_string_n_field(begin, __%smin( end, N ## _vec_len(vec) ), N ## _ ## NK, vec, N ## _vec_at, N ## _vec_len, s, n)\n",
-        nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc);
+        nsc, nsc, nsc, nsc, nsc, nsc, nsc);
     fprintf(out->fp,
         "#define __%sdefine_default_scan_by_scalar_field(N, NK, TK)\\\n"
         "static inline size_t N ## _vec_scan(N ## _vec_t vec, TK key)\\\n"
         "{ return N ## _vec_scan_by_ ## NK(vec, key); }\\\n"
-        "static inline size_t N ## _vec_scan_from(N ## _vec_t vec, size_t pos, TK key)\\\n"
-        "{ return N ## _vec_scan_from_by_ ## NK(vec, pos, key); }\\\n"
-        "static inline size_t N ## _vec_scan_range(N ## _vec_t vec, size_t begin, size_t end, TK key)\\\n"
-        "{ return N ## _vec_scan_range_by_ ## NK(vec, begin, end, key); }\n",
+        "static inline size_t N ## _vec_scan_ex(N ## _vec_t vec, size_t begin, size_t end, TK key)\\\n"
+        "{ return N ## _vec_scan_ex_by_ ## NK(vec, begin, end, key); }\n",
         nsc);
     fprintf(out->fp,
         "#define __%sdefine_default_scan_by_string_field(N, NK) \\\n"
@@ -245,14 +236,10 @@ static void gen_scan(fb_output_t *out)
         "{ return N ## _vec_scan_by_ ## NK(vec, s); }\\\n"
         "static inline size_t N ## _vec_scan_n(N ## _vec_t vec, const char *s, int n)\\\n"
         "{ return N ## _vec_scan_n_by_ ## NK(vec, s, n); }\\\n"
-        "static inline size_t N ## _vec_scan_from(N ## _vec_t vec, size_t pos, const char *s)\\\n"
-        "{ return N ## _vec_scan_from_by_ ## NK(vec, pos, s); }\\\n"
-        "static inline size_t N ## _vec_scan_n_from(N ## _vec_t vec, size_t pos, const char *s, int n)\\\n"
-        "{ return N ## _vec_scan_n_from_by_ ## NK(vec, pos, s, n); }\\\n"
-        "static inline size_t N ## _vec_scan_range(N ## _vec_t vec, size_t begin, size_t end, const char *s)\\\n"
-        "{ return N ## _vec_scan_range_by_ ## NK(vec, begin, end, s); }\\\n"
-        "static inline size_t N ## _vec_scan_n_range(N ## _vec_t vec, size_t begin, size_t end, const char *s, int n)\\\n"
-        "{ return N ## _vec_scan_n_range_by_ ## NK(vec, begin, end, s, n); }\n",
+        "static inline size_t N ## _vec_scan_ex(N ## _vec_t vec, size_t begin, size_t end, const char *s)\\\n"
+        "{ return N ## _vec_scan_ex_by_ ## NK(vec, begin, end, s); }\\\n"
+        "static inline size_t N ## _vec_scan_ex_n(N ## _vec_t vec, size_t begin, size_t end, const char *s, int n)\\\n"
+        "{ return N ## _vec_scan_ex_n_by_ ## NK(vec, begin, end, s, n); }\n",
         nsc);
 }
 
@@ -474,17 +461,13 @@ static void gen_helpers(fb_output_t *out)
             "__%sscan_by_string_field(0, %sstring_vec_len(vec), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s)\n"
             "static inline size_t %sstring_vec_scan_n(%sstring_vec_t vec, const char *s, size_t n)\n"
             "__%sscan_by_string_n_field(0, %sstring_vec_len(vec), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n"
-            "static inline size_t %sstring_vec_scan_from(%sstring_vec_t vec, size_t pos, const char *s)\n"
-            "__%sscan_by_string_field(pos, %sstring_vec_len(vec), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s)\n"
-            "static inline size_t %sstring_vec_scan_n_at(%sstring_vec_t vec, size_t pos, const char *s, size_t n)\n"
-            "__%sscan_by_string_n_field(pos, %sstring_vec_len(vec), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n"
-            "static inline size_t %sstring_vec_scan_range(%sstring_vec_t vec, size_t begin, size_t end, const char *s)\n"
+            "static inline size_t %sstring_vec_scan_ex(%sstring_vec_t vec, size_t begin, size_t end, const char *s)\n"
             "__%sscan_by_string_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s)\n"
-            "static inline size_t %sstring_vec_scan_n_range(%sstring_vec_t vec, size_t begin, size_t end, const char *s, size_t n)\n"
+            "static inline size_t %sstring_vec_scan_ex_n(%sstring_vec_t vec, size_t begin, size_t end, const char *s, size_t n)\n"
             "__%sscan_by_string_n_field(begin, __%smin(end, %sstring_vec_len(vec)), __%sidentity, vec, %sstring_vec_at, %sstring_vec_len, s, n)\n",
             nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc,
             nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc,
-            nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc, nsc);
+            nsc, nsc);
     if (out->opts->cgen_sort) {
         fprintf(out->fp, "__%sdefine_string_sort()\n", nsc);
     }

--- a/src/compiler/flatcc.c
+++ b/src/compiler/flatcc.c
@@ -19,6 +19,7 @@ void flatcc_init_options(flatcc_options_t *opts)
     opts->allow_enum_key = FLATCC_ALLOW_ENUM_KEY;
     opts->allow_enum_struct_field = FLATCC_ALLOW_ENUM_STRUCT_FIELD;
     opts->allow_multiple_key_fields = FLATCC_ALLOW_MULTIPLE_KEY_FIELDS;
+    opts->allow_scan_for_all_fields = FLATCC_ALLOW_SCAN_FOR_ALL_FIELDS;
     opts->allow_string_key = FLATCC_ALLOW_STRING_KEY;
     opts->allow_struct_field_deprecate = FLATCC_ALLOW_STRUCT_FIELD_DEPRECATE;
     opts->allow_struct_field_key = FLATCC_ALLOW_STRUCT_FIELD_KEY;

--- a/test/monster_test/monster_test.c
+++ b/test/monster_test/monster_test.c
@@ -1109,7 +1109,7 @@ static size_t count_monsters(ns(Monster_vec_t) monsters, const char *name)
 
     for (i = ns(Monster_vec_scan)(monsters, name);
          i != nsc(not_found);
-         i = ns(Monster_vec_scan_from)(monsters, i + 1, name)) {
+         i = ns(Monster_vec_scan_ex)(monsters, i + 1, nsc(end), name)) {
         ++count;
     }
 
@@ -1173,7 +1173,7 @@ int test_scan_by(flatcc_builder_t *B)
         printf("scan_by did not find the Joker with n\n");
         goto done;
     }
-    if (nsc(not_found) != ns(Monster_vec_scan_from(monsters, 2, "Joker"))) {
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, 2, nsc(end), "Joker"))) {
         printf("scan_from found Joker past first occurence\n");
         goto done;
     }
@@ -1189,32 +1189,32 @@ int test_scan_by(flatcc_builder_t *B)
         printf("Gulliver not found\n");
         goto done;
     }
-    if (2 != ns(Monster_vec_scan_from_by_name(monsters, 2, "Gulliver"))) {
+    if (2 != ns(Monster_vec_scan_ex_by_name(monsters, 2, nsc(end), "Gulliver"))) {
         printf("Gulliver not found starting from Gulliver\n");
         goto done;
     }
-    if (4 != ns(Monster_vec_scan_from_by_name(monsters, 3, "Gulliver"))) {
+    if (4 != ns(Monster_vec_scan_ex_by_name(monsters, 3, nsc(end), "Gulliver"))) {
         printf("Another Gulliver not found\n");
         goto done;
     }
 
-    if (nsc(not_found) != ns(Monster_vec_scan_range(monsters, 1, 3, "Jingle"))) {
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, 1, 3, "Jingle"))) {
         printf("not found in subrange not working\n");
         goto done;
     }
-    if (nsc(not_found) != ns(Monster_vec_scan_range(monsters, 1, 3, "TwoFace"))) {
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, 1, 3, "TwoFace"))) {
         printf("subrange doesn't limit low bound\n");
         goto done;
     }
-    if (1 != ns(Monster_vec_scan_range(monsters, 1, 3, "Joker"))) {
+    if (1 != ns(Monster_vec_scan_ex(monsters, 1, 3, "Joker"))) {
         printf("scan in subrange did not find Joker\n");
         goto done;
     }
-    if (2 != ns(Monster_vec_scan_range_by_name(monsters, 1, 3, "Gulliver"))) {
+    if (2 != ns(Monster_vec_scan_ex_by_name(monsters, 1, 3, "Gulliver"))) {
         printf("scan in subrange did not find Gulliver\n");
         goto done;
     }
-    if (nsc(not_found) != ns(Monster_vec_scan_range_by_name(monsters, 1, 3, "Alice"))) {
+    if (nsc(not_found) != ns(Monster_vec_scan_ex_by_name(monsters, 1, 3, "Alice"))) {
         printf("subrange doesn't limit upper bound\n");
         goto done;
     }
@@ -1245,7 +1245,7 @@ int test_scan_by(flatcc_builder_t *B)
         printf("scan not working on middle item of inventory\n");
         goto done;
     }
-    if (nsc(not_found) != (pos = nsc(uint8_vec_scan_from(inv, 3, 1)))) {
+    if (nsc(not_found) != (pos = nsc(uint8_vec_scan_ex(inv, 3, nsc(end), 1)))) {
         printf("scan_from(item+1) not working on middle item of inventory\n");
         goto done;
     }
@@ -1261,11 +1261,11 @@ int test_scan_by(flatcc_builder_t *B)
         printf("scan not working for repeating item of inventory\n");
         goto done;
     }
-    if (3 != (pos = nsc(uint8_vec_scan_from(inv, 3, 3)))) {
+    if (3 != (pos = nsc(uint8_vec_scan_ex(inv, 3, nsc(end), 3)))) {
         printf("scan_from(item) not working for repeating item of inventory\n");
         goto done;
     }
-    if (5 != (pos = nsc(uint8_vec_scan_from(inv, 4, 3)))) {
+    if (5 != (pos = nsc(uint8_vec_scan_ex(inv, 4, nsc(end), 3)))) {
         printf("scan_from(item+1) not working for repeating item of inventory\n");
         goto done;
     }

--- a/test/monster_test/monster_test.c
+++ b/test/monster_test/monster_test.c
@@ -1169,6 +1169,10 @@ int test_scan_by(flatcc_builder_t *B)
         printf("scan_by did not find the Joker\n");
         goto done;
     }
+    if (1 != ns(Monster_vec_rscan(monsters, "Joker"))) {
+        printf("rscan_by did not find the Joker\n");
+        goto done;
+    }
     if (1 != ns(Monster_vec_scan_n(monsters, "Joker3", 5))) {
         printf("scan_by did not find the Joker with n\n");
         goto done;
@@ -1186,6 +1190,10 @@ int test_scan_by(flatcc_builder_t *B)
         goto done;
     }
     if (2 != ns(Monster_vec_scan_by_name(monsters, "Gulliver"))) {
+        printf("Gulliver not found\n");
+        goto done;
+    }
+    if (4 != ns(Monster_vec_rscan_by_name(monsters, "Gulliver"))) {
         printf("Gulliver not found\n");
         goto done;
     }

--- a/test/monster_test/monster_test.c
+++ b/test/monster_test/monster_test.c
@@ -5,6 +5,7 @@
 
 #include "flatcc/support/hexdump.h"
 #include "flatcc/support/elapsed.h"
+#include "../../config/config.h"
 
 /*
  * Convenience macro to deal with long namespace names,
@@ -1116,12 +1117,13 @@ static size_t count_monsters(ns(Monster_vec_t) monsters, const char *name)
     return count;
 }
 
-int test_scan_by(flatcc_builder_t *B)
+int test_scan(flatcc_builder_t *B)
 {
     size_t pos;
     ns(Monster_table_t) mon;
     ns(Monster_vec_t) monsters;
     nsc(uint8_vec_t) inv;
+    nsc(string_vec_t) strings;
     void *buffer;
     size_t size;
     uint8_t invdata[] = { 6, 7, 1, 3, 4, 3, 2 };
@@ -1131,6 +1133,9 @@ int test_scan_by(flatcc_builder_t *B)
     ns(Monster_start_as_root(B));
     ns(Monster_name_create_str(B, "MyMonster"));
     ns(Monster_inventory_create(B, invdata, c_vec_len(invdata)));
+
+    ns(Monster_testarrayofstring_start(B));
+    ns(Monster_testarrayofstring_end(B));
 
     ns(Monster_testarrayoftables_start(B));
 
@@ -1164,6 +1169,8 @@ int test_scan_by(flatcc_builder_t *B)
     assert(monsters);
     inv = ns(Monster_inventory(mon));
     assert(inv);
+    strings = ns(Monster_testarrayofstring(mon));
+    assert(strings);
 
     if (1 != ns(Monster_vec_scan(monsters, "Joker"))) {
         printf("scan_by did not find the Joker\n");
@@ -1174,6 +1181,10 @@ int test_scan_by(flatcc_builder_t *B)
         goto done;
     }
     if (1 != ns(Monster_vec_scan_n(monsters, "Joker3", 5))) {
+        printf("scan_by did not find the Joker with n\n");
+        goto done;
+    }
+    if (1 != ns(Monster_vec_rscan_n(monsters, "Joker3", 5))) {
         printf("scan_by did not find the Joker with n\n");
         goto done;
     }
@@ -1197,7 +1208,19 @@ int test_scan_by(flatcc_builder_t *B)
         printf("Gulliver not found\n");
         goto done;
     }
+    if (4 != ns(Monster_vec_rscan_n_by_name(monsters, "Gulliver42", 8))) {
+        printf("Gulliver not found with n\n");
+        goto done;
+    }
+    if (2 != ns(Monster_vec_rscan_ex_n_by_name(monsters, 1, 3, "Gulliver42", 8))) {
+        printf("Gulliver not found with n\n");
+        goto done;
+    }
     if (2 != ns(Monster_vec_scan_ex_by_name(monsters, 2, nsc(end), "Gulliver"))) {
+        printf("Gulliver not found starting from Gulliver\n");
+        goto done;
+    }
+    if (2 != ns(Monster_vec_scan_ex_n_by_name(monsters, 2, nsc(end), "Gulliver42", 8))) {
         printf("Gulliver not found starting from Gulliver\n");
         goto done;
     }
@@ -1223,10 +1246,64 @@ int test_scan_by(flatcc_builder_t *B)
         goto done;
     }
     if (nsc(not_found) != ns(Monster_vec_scan_ex_by_name(monsters, 1, 3, "Alice"))) {
-        printf("subrange doesn't limit upper bound\n");
+        printf("subrange doesn't limit upper bound in scan\n");
         goto done;
     }
 
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex(monsters, 1, 3, "Jingle"))) {
+        printf("not found in subrange not working with rscan\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex(monsters, 1, 3, "TwoFace"))) {
+        printf("subrange doesn't limit lower bound in rscan\n");
+        goto done;
+    }
+    if (1 != ns(Monster_vec_rscan_ex(monsters, 1, 3, "Joker"))) {
+        printf("rscan in subrange did not find Joker\n");
+        goto done;
+    }
+    if (2 != ns(Monster_vec_rscan_ex_by_name(monsters, 1, 3, "Gulliver"))) {
+        printf("rscan in subrange did not find Gulliver\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex_by_name(monsters, 1, 3, "Alice"))) {
+        printf("subrange doesn't limit upper bound in rscan\n");
+        goto done;
+    }
+
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, 0, 0, "TwoFace"))) {
+        printf("TwoFace is found in empty range\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, 0, 0, "Joker"))) {
+        printf("Joker is found in empty range\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, 1, 1, "Joker"))) {
+        printf("Joker is found in another empty range\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_scan_ex(monsters, ns(Monster_vec_len(monsters)), nsc(end), "TwoFace"))) {
+        printf("TwoFace is found in empty range in the end\n");
+        goto done;
+    }
+
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex(monsters, 0, 0, "TwoFace"))) {
+        printf("TwoFace is found in empty range\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex(monsters, 0, 0, "Joker"))) {
+        printf("Joker is found in empty range\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex(monsters, 1, 1, "Joker"))) {
+        printf("Joker is found in another empty range\n");
+        goto done;
+    }
+    if (nsc(not_found) != ns(Monster_vec_rscan_ex(monsters, ns(Monster_vec_len(monsters)), nsc(end), "TwoFace"))) {
+        printf("TwoFace is found in empty range in the end\n");
+        goto done;
+    }
 
     if (1 != count_monsters(monsters, "Joker")) {
         printf("number of Jokers is not 1\n");
@@ -1245,6 +1322,7 @@ int test_scan_by(flatcc_builder_t *B)
         goto done;
     }
 
+
     if (0 != (pos = nsc(uint8_vec_scan(inv, 6)))) {
         printf("scan not working on first item of inventory\n");
         goto done;
@@ -1254,7 +1332,7 @@ int test_scan_by(flatcc_builder_t *B)
         goto done;
     }
     if (nsc(not_found) != (pos = nsc(uint8_vec_scan_ex(inv, 3, nsc(end), 1)))) {
-        printf("scan_from(item+1) not working on middle item of inventory\n");
+        printf("scan_ex(item+1) not working on middle item of inventory\n");
         goto done;
     }
     if (nsc(not_found) != (pos = nsc(uint8_vec_scan(inv, 5)))) {
@@ -1270,13 +1348,39 @@ int test_scan_by(flatcc_builder_t *B)
         goto done;
     }
     if (3 != (pos = nsc(uint8_vec_scan_ex(inv, 3, nsc(end), 3)))) {
-        printf("scan_from(item) not working for repeating item of inventory\n");
+        printf("scan_ex(item) not working for repeating item of inventory\n");
         goto done;
     }
     if (5 != (pos = nsc(uint8_vec_scan_ex(inv, 4, nsc(end), 3)))) {
-        printf("scan_from(item+1) not working for repeating item of inventory\n");
+        printf("scan_ex(item+1) not working for repeating item of inventory\n");
         goto done;
     }
+    if (5 != (pos = nsc(uint8_vec_rscan(inv, 3)))) {
+        printf("rscan not working for repeating item of inventory\n");
+        goto done;
+    }
+    if (3 != (pos = nsc(uint8_vec_rscan_ex(inv, 1, 4, 3)))) {
+        printf("rscan_ex not working for repeating item of inventory\n");
+        goto done;
+    }
+
+    /* Test that all scan functions are generated for string arrays */
+    nsc(string_vec_scan(strings, "Hello"));
+    nsc(string_vec_scan_ex(strings, 0, nsc(end), "Hello"));
+    nsc(string_vec_scan_n(strings, "Hello", 4));
+    nsc(string_vec_scan_ex_n(strings, 0, nsc(end), "Hello", 4));
+    nsc(string_vec_rscan(strings, "Hello"));
+    nsc(string_vec_rscan_ex(strings, 0, nsc(end), "Hello"));
+    nsc(string_vec_rscan_n(strings, "Hello", 4));
+    nsc(string_vec_rscan_ex_n(strings, 0, nsc(end), "Hello", 4));
+
+#if FLATCC_ALLOW_SCAN_FOR_ALL_FIELDS
+    /* Check for presence of scan for non-key fields */
+    ns(Monster_vec_scan_by_hp(monsters, 13));
+    ns(Monster_vec_scan_ex_by_hp(monsters, 1, nsc(end), 42));
+    ns(Monster_vec_rscan_by_hp(monsters, 1));
+    ns(Monster_vec_rscan_ex_by_hp(monsters, 0, 2, 42));
+#endif
 
     ret = 0;
 
@@ -1964,7 +2068,7 @@ int main(int argc, char *argv[])
     }
 #endif
 #if 1
-    if (test_scan_by(B)) {
+    if (test_scan(B)) {
         printf("TEST FAILED\n");
         return -1;
     }


### PR DESCRIPTION
We discussed possibility of adding scan functions for all fields as a default option and I tried to implement it.  I also tried in my project to remove keys from fields, regenerate headers with new flatcc and measure compilation time on my laptop. After several clean runs of "time make all" it became apparent that there is no noticeable effect on compilation time (7.5 sec before and after on average) nor binaries size (514K executable compiled in debug mode). Reader header size became even smaller (21K before, 20K after).