### PR TITLE
fix compatibility with C++ compilers.

### DIFF
--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -78,7 +78,7 @@ const char *flatcc_json_parser_error_string(int err);
  */
 typedef struct flatcc_json_parser_ctx flatcc_json_parser_t;
 struct flatcc_json_parser_ctx {
-    void *ctx;
+    flatcc_builder_t *ctx;
     const char *line_start;
     int flags;
 #if FLATCC_JSON_PARSE_ALLOW_UNQUOTED

--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -170,21 +170,21 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
     fprintf(out->fp,
         "#define __%sbuild_vector_ops(NS, V, N, TN, T)\\\n"
         "static inline T *V ## _extend(NS ## builder_t *B, size_t len)\\\n"
-        "{ return (T *) flatcc_builder_extend_vector(B, len); }\\\n"
+        "{ return (T *)flatcc_builder_extend_vector(B, len); }\\\n"
         "static inline T *V ## _append(NS ## builder_t *B, const T *data, size_t len)\\\n"
-        "{ return (T *) flatcc_builder_append_vector(B, data, len); }\\\n"
+        "{ return (T *)flatcc_builder_append_vector(B, data, len); }\\\n"
         "static inline int V ## _truncate(NS ## builder_t *B, size_t len)\\\n"
         "{ return flatcc_builder_truncate_vector(B, len); }\\\n"
         "static inline T *V ## _edit(NS ## builder_t *B)\\\n"
-        "{ return (T *) flatcc_builder_vector_edit(B); }\\\n"
+        "{ return (T *)flatcc_builder_vector_edit(B); }\\\n"
         "static inline size_t V ## _reserved_len(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_vector_count(B); }\\\n"
         "static inline T *V ## _push(NS ## builder_t *B, const T *p)\\\n"
-        "{ T *_p; return (_p = (T *) flatcc_builder_extend_vector(B, 1)) ? (memcpy(_p, p, TN ## __size()), _p) : 0; }\\\n"
+        "{ T *_p; return (_p = (T *)flatcc_builder_extend_vector(B, 1)) ? (memcpy(_p, p, TN ## __size()), _p) : 0; }\\\n"
         "static inline T *V ## _push_copy(NS ## builder_t *B, const T *p)\\\n"
-        "{ T *_p; return (_p = (T *) flatcc_builder_extend_vector(B, 1)) ? TN ## _copy(_p, p) : 0; }\\\n"
+        "{ T *_p; return (_p = (T *)flatcc_builder_extend_vector(B, 1)) ? TN ## _copy(_p, p) : 0; }\\\n"
         "static inline T *V ## _push_create(NS ## builder_t *B __ ## TN ## _formal_args)\\\n"
-        "{ T *_p; return (_p = (T *) flatcc_builder_extend_vector(B, 1)) ? TN ## _assign(_p __ ## TN ## _call_args) : 0; }\n"
+        "{ T *_p; return (_p = (T *)flatcc_builder_extend_vector(B, 1)) ? TN ## _assign(_p __ ## TN ## _call_args) : 0; }\n"
         "\n",
         nsc);
 
@@ -197,14 +197,14 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline N ## _vec_ref_t N ## _vec_end_pe(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_end_vector(B); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_end(NS ## builder_t *B)\\\n"
-        "{ if (!NS ## is_native_pe()) { size_t i, n; T *p = (T *) flatcc_builder_vector_edit(B);\\\n"
+        "{ if (!NS ## is_native_pe()) { size_t i, n; T *p = (T *)flatcc_builder_vector_edit(B);\\\n"
         "    for (i = 0, n = flatcc_builder_vector_count(B); i < n; ++i)\\\n"
         "    { N ## _to_pe(N ## __ptr_add(p, i)); }} return flatcc_builder_end_vector(B); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_create_pe(NS ## builder_t *B, const T *data, size_t len)\\\n"
         "{ return flatcc_builder_create_vector(B, data, len, S, A, FLATBUFFERS_COUNT_MAX(S)); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_create(NS ## builder_t *B, const T *data, size_t len)\\\n"
         "{ if (!NS ## is_native_pe()) { size_t i; T *p; int ret = flatcc_builder_start_vector(B, S, A, FLATBUFFERS_COUNT_MAX(S)); if (ret) { return ret; }\\\n"
-        "  p = (T *) flatcc_builder_extend_vector(B, len); if (!p) return 0;\\\n"
+        "  p = (T *)flatcc_builder_extend_vector(B, len); if (!p) return 0;\\\n"
         "  for (i = 0; i < len; ++i) { N ## _copy_to_pe(N ## __ptr_add(p, i), N ## __const_ptr_add(data, i)); }\\\n"
         "  return flatcc_builder_end_vector(B); } else return flatcc_builder_create_vector(B, data, len, S, A, FLATBUFFERS_COUNT_MAX(S)); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_clone(NS ## builder_t *B, N ##_vec_t vec)\\\n"
@@ -257,7 +257,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline int V ## _truncate(NS ## builder_t *B, size_t len)\\\n"
         "{ return flatcc_builder_truncate_offset_vector(B, len); }\\\n"
         "static inline TN ## _ref_t *V ## _edit(NS ## builder_t *B)\\\n"
-        "{ return (TN ## _ref_t *) flatcc_builder_offset_vector_edit(B); }\\\n"
+        "{ return (TN ## _ref_t *)flatcc_builder_offset_vector_edit(B); }\\\n"
         "static inline size_t V ## _reserved_len(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_offset_vector_count(B); }\\\n"
         "static inline TN ## _ref_t *V ## _push(NS ## builder_t *B, const TN ## _ref_t ref)\\\n"
@@ -358,7 +358,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "__ ## NS ## define_struct_primitives(NS, N)\\\n"
         "typedef NS ## ref_t N ## _ref_t;\\\n"
         "static inline N ## _t *N ## _start(NS ## builder_t *B)\\\n"
-        "{ return (N ## _t *) flatcc_builder_start_struct(B, S, A); }\\\n"
+        "{ return (N ## _t *)flatcc_builder_start_struct(B, S, A); }\\\n"
         "static inline N ## _ref_t N ## _end(NS ## builder_t *B)\\\n"
         "{ if (!NS ## is_native_pe()) { N ## _to_pe(flatcc_builder_struct_edit(B)); }\\\n"
         "  return flatcc_builder_end_struct(B); }\\\n"
@@ -403,10 +403,10 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "#define __%sbuild_union_field(ID, NS, N, TN)\\\n"
         "static inline int N ## _add(NS ## builder_t *B, TN ## _union_ref_t uref)\\\n"
         "{ NS ## ref_t *_p; TN ## _union_type_t *_pt; if (uref.type == TN ## _NONE) return 0; if (uref._member == 0) return -1;\\\n"
-        "  if (!(_pt = (TN ## _union_type_t *) flatcc_builder_table_add(B, ID - 1, sizeof(*_pt), sizeof(_pt))) ||\\\n"
+        "  if (!(_pt = (TN ## _union_type_t *)flatcc_builder_table_add(B, ID - 1, sizeof(*_pt), sizeof(_pt))) ||\\\n"
         "  !(_p = flatcc_builder_table_add_offset(B, ID))) return -1; *_pt = uref.type; *_p = uref._member; return 0; }\\\n"
         "static inline int N ## _add_type(NS ## builder_t *B, TN ## _union_type_t type)\\\n"
-        "{ TN ## _union_type_t *_pt; if (type == TN ## _NONE) return 0; return (_pt = (TN ## _union_type_t *) flatcc_builder_table_add(B, ID - 1,\\\n"
+        "{ TN ## _union_type_t *_pt; if (type == TN ## _NONE) return 0; return (_pt = (TN ## _union_type_t *)flatcc_builder_table_add(B, ID - 1,\\\n"
         "  sizeof(*_pt), sizeof(*_pt))) ? ((*_pt = type), 0) : -1; }\\\n"
         "static inline int N ## _add_member(NS ## builder_t *B, TN ## _union_ref_t uref)\\\n"
         "{ NS ## ref_t *p; if (uref.type == TN ## _NONE) return 0; return (p = flatcc_builder_table_add_offset(B, ID)) ?\\\n"
@@ -431,10 +431,10 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         " * S: sizeof of scalar type, A: alignment of type T, default value V of type T. */\n"
         "#define __%sbuild_scalar_field(ID, NS, N, TN, T, S, A, V)\\\n"
         "static inline int N ## _add(NS ## builder_t *B, const T v)\\\n"
-        "{ T *_p; if (v == V) return 0; if (!(_p = (T *) flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
+        "{ T *_p; if (v == V) return 0; if (!(_p = (T *)flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
         "  TN ## _assign_to_pe(_p, v); return 0; }\\\n"
         "static inline int N ## _force_add(NS ## builder_t *B, const T v)\\\n"
-        "{ T *_p; if (!(_p = (T *) flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
+        "{ T *_p; if (!(_p = (T *)flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
         "  TN ## _assign_to_pe(_p, v); return 0; }\\\n"
         "\n",
         nsc);
@@ -602,7 +602,7 @@ static int gen_builder_pretext(fb_output_t *out)
     if (out->S->file_identifier.type == vt_string) {
         fprintf(out->fp,
             "#undef %sidentifier\n"
-            "#define %sidentifier (*((flatbuffers_fid_t *) \"%.*s\"))\n",
+            "#define %sidentifier \"%.*s\"\n",
             nsc,
             nsc, out->S->file_identifier.s.len, out->S->file_identifier.s.s);
     } else {

--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -442,7 +442,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
     fprintf(out->fp,
         "#define __%sbuild_struct_field(ID, NS, N, TN, S, A)\\\n"
         "static inline TN ## _t *N ## _start(NS ## builder_t *B)\\\n"
-        "{ return (TN ## _t *) flatcc_builder_table_add(B, ID, S, A); }\\\n"
+        "{ return (TN ## _t *)flatcc_builder_table_add(B, ID, S, A); }\\\n"
         "static inline int N ## _end(NS ## builder_t *B)\\\n"
         "{ if (!NS ## is_native_pe()) { TN ## _to_pe(flatcc_builder_table_edit(B, S)); } return 0; }\\\n"
         "static inline int N ## _end_pe(NS ## builder_t *B) { return 0; }\\\n"

--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -170,21 +170,21 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
     fprintf(out->fp,
         "#define __%sbuild_vector_ops(NS, V, N, TN, T)\\\n"
         "static inline T *V ## _extend(NS ## builder_t *B, size_t len)\\\n"
-        "{ return flatcc_builder_extend_vector(B, len); }\\\n"
+        "{ return (T *) flatcc_builder_extend_vector(B, len); }\\\n"
         "static inline T *V ## _append(NS ## builder_t *B, const T *data, size_t len)\\\n"
-        "{ return flatcc_builder_append_vector(B, data, len); }\\\n"
+        "{ return (T *) flatcc_builder_append_vector(B, data, len); }\\\n"
         "static inline int V ## _truncate(NS ## builder_t *B, size_t len)\\\n"
         "{ return flatcc_builder_truncate_vector(B, len); }\\\n"
         "static inline T *V ## _edit(NS ## builder_t *B)\\\n"
-        "{ return flatcc_builder_vector_edit(B); }\\\n"
+        "{ return (T *) flatcc_builder_vector_edit(B); }\\\n"
         "static inline size_t V ## _reserved_len(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_vector_count(B); }\\\n"
         "static inline T *V ## _push(NS ## builder_t *B, const T *p)\\\n"
-        "{ T *_p; return (_p = flatcc_builder_extend_vector(B, 1)) ? (memcpy(_p, p, TN ## __size()), _p) : 0; }\\\n"
+        "{ T *_p; return (_p = (T *) flatcc_builder_extend_vector(B, 1)) ? (memcpy(_p, p, TN ## __size()), _p) : 0; }\\\n"
         "static inline T *V ## _push_copy(NS ## builder_t *B, const T *p)\\\n"
-        "{ T *_p; return (_p = flatcc_builder_extend_vector(B, 1)) ? TN ## _copy(_p, p) : 0; }\\\n"
+        "{ T *_p; return (_p = (T *) flatcc_builder_extend_vector(B, 1)) ? TN ## _copy(_p, p) : 0; }\\\n"
         "static inline T *V ## _push_create(NS ## builder_t *B __ ## TN ## _formal_args)\\\n"
-        "{ T *_p; return (_p = flatcc_builder_extend_vector(B, 1)) ? TN ## _assign(_p __ ## TN ## _call_args) : 0; }\n"
+        "{ T *_p; return (_p = (T *) flatcc_builder_extend_vector(B, 1)) ? TN ## _assign(_p __ ## TN ## _call_args) : 0; }\n"
         "\n",
         nsc);
 
@@ -197,14 +197,14 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline N ## _vec_ref_t N ## _vec_end_pe(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_end_vector(B); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_end(NS ## builder_t *B)\\\n"
-        "{ if (!NS ## is_native_pe()) { size_t i, n; T *p = flatcc_builder_vector_edit(B);\\\n"
+        "{ if (!NS ## is_native_pe()) { size_t i, n; T *p = (T *) flatcc_builder_vector_edit(B);\\\n"
         "    for (i = 0, n = flatcc_builder_vector_count(B); i < n; ++i)\\\n"
         "    { N ## _to_pe(N ## __ptr_add(p, i)); }} return flatcc_builder_end_vector(B); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_create_pe(NS ## builder_t *B, const T *data, size_t len)\\\n"
         "{ return flatcc_builder_create_vector(B, data, len, S, A, FLATBUFFERS_COUNT_MAX(S)); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_create(NS ## builder_t *B, const T *data, size_t len)\\\n"
         "{ if (!NS ## is_native_pe()) { size_t i; T *p; int ret = flatcc_builder_start_vector(B, S, A, FLATBUFFERS_COUNT_MAX(S)); if (ret) { return ret; }\\\n"
-        "  p = flatcc_builder_extend_vector(B, len); if (!p) return 0;\\\n"
+        "  p = (T *) flatcc_builder_extend_vector(B, len); if (!p) return 0;\\\n"
         "  for (i = 0; i < len; ++i) { N ## _copy_to_pe(N ## __ptr_add(p, i), N ## __const_ptr_add(data, i)); }\\\n"
         "  return flatcc_builder_end_vector(B); } else return flatcc_builder_create_vector(B, data, len, S, A, FLATBUFFERS_COUNT_MAX(S)); }\\\n"
         "static inline N ## _vec_ref_t N ## _vec_clone(NS ## builder_t *B, N ##_vec_t vec)\\\n"
@@ -257,7 +257,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline int V ## _truncate(NS ## builder_t *B, size_t len)\\\n"
         "{ return flatcc_builder_truncate_offset_vector(B, len); }\\\n"
         "static inline TN ## _ref_t *V ## _edit(NS ## builder_t *B)\\\n"
-        "{ return flatcc_builder_offset_vector_edit(B); }\\\n"
+        "{ return (TN ## _ref_t *) flatcc_builder_offset_vector_edit(B); }\\\n"
         "static inline size_t V ## _reserved_len(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_offset_vector_count(B); }\\\n"
         "static inline TN ## _ref_t *V ## _push(NS ## builder_t *B, const TN ## _ref_t ref)\\\n"
@@ -358,7 +358,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "__ ## NS ## define_struct_primitives(NS, N)\\\n"
         "typedef NS ## ref_t N ## _ref_t;\\\n"
         "static inline N ## _t *N ## _start(NS ## builder_t *B)\\\n"
-        "{ return flatcc_builder_start_struct(B, S, A); }\\\n"
+        "{ return (N ## _t *) flatcc_builder_start_struct(B, S, A); }\\\n"
         "static inline N ## _ref_t N ## _end(NS ## builder_t *B)\\\n"
         "{ if (!NS ## is_native_pe()) { N ## _to_pe(flatcc_builder_struct_edit(B)); }\\\n"
         "  return flatcc_builder_end_struct(B); }\\\n"
@@ -403,10 +403,10 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "#define __%sbuild_union_field(ID, NS, N, TN)\\\n"
         "static inline int N ## _add(NS ## builder_t *B, TN ## _union_ref_t uref)\\\n"
         "{ NS ## ref_t *_p; TN ## _union_type_t *_pt; if (uref.type == TN ## _NONE) return 0; if (uref._member == 0) return -1;\\\n"
-        "  if (!(_pt = flatcc_builder_table_add(B, ID - 1, sizeof(*_pt), sizeof(_pt))) ||\\\n"
+        "  if (!(_pt = (TN ## _union_type_t *) flatcc_builder_table_add(B, ID - 1, sizeof(*_pt), sizeof(_pt))) ||\\\n"
         "  !(_p = flatcc_builder_table_add_offset(B, ID))) return -1; *_pt = uref.type; *_p = uref._member; return 0; }\\\n"
         "static inline int N ## _add_type(NS ## builder_t *B, TN ## _union_type_t type)\\\n"
-        "{ TN ## _union_type_t *_pt; if (type == TN ## _NONE) return 0; return (_pt = flatcc_builder_table_add(B, ID - 1,\\\n"
+        "{ TN ## _union_type_t *_pt; if (type == TN ## _NONE) return 0; return (_pt = (TN ## _union_type_t *) flatcc_builder_table_add(B, ID - 1,\\\n"
         "  sizeof(*_pt), sizeof(*_pt))) ? ((*_pt = type), 0) : -1; }\\\n"
         "static inline int N ## _add_member(NS ## builder_t *B, TN ## _union_ref_t uref)\\\n"
         "{ NS ## ref_t *p; if (uref.type == TN ## _NONE) return 0; return (p = flatcc_builder_table_add_offset(B, ID)) ?\\\n"
@@ -431,10 +431,10 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         " * S: sizeof of scalar type, A: alignment of type T, default value V of type T. */\n"
         "#define __%sbuild_scalar_field(ID, NS, N, TN, T, S, A, V)\\\n"
         "static inline int N ## _add(NS ## builder_t *B, const T v)\\\n"
-        "{ T *_p; if (v == V) return 0; if (!(_p = flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
+        "{ T *_p; if (v == V) return 0; if (!(_p = (T *) flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
         "  TN ## _assign_to_pe(_p, v); return 0; }\\\n"
         "static inline int N ## _force_add(NS ## builder_t *B, const T v)\\\n"
-        "{ T *_p; if (!(_p = flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
+        "{ T *_p; if (!(_p = (T *) flatcc_builder_table_add(B, ID, S, A))) return -1;\\\n"
         "  TN ## _assign_to_pe(_p, v); return 0; }\\\n"
         "\n",
         nsc);
@@ -442,7 +442,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
     fprintf(out->fp,
         "#define __%sbuild_struct_field(ID, NS, N, TN, S, A)\\\n"
         "static inline TN ## _t *N ## _start(NS ## builder_t *B)\\\n"
-        "{ return flatcc_builder_table_add(B, ID, S, A); }\\\n"
+        "{ return (TN ## _t *) flatcc_builder_table_add(B, ID, S, A); }\\\n"
         "static inline int N ## _end(NS ## builder_t *B)\\\n"
         "{ if (!NS ## is_native_pe()) { TN ## _to_pe(flatcc_builder_table_edit(B, S)); } return 0; }\\\n"
         "static inline int N ## _end_pe(NS ## builder_t *B) { return 0; }\\\n"
@@ -602,7 +602,7 @@ static int gen_builder_pretext(fb_output_t *out)
     if (out->S->file_identifier.type == vt_string) {
         fprintf(out->fp,
             "#undef %sidentifier\n"
-            "#define %sidentifier \"%.*s\"\n",
+            "#define %sidentifier (*((flatbuffers_fid_t *) \"%.*s\"))\n",
             nsc,
             nsc, out->S->file_identifier.s.len, out->S->file_identifier.s.s);
     } else {

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -1395,7 +1395,7 @@ static int gen_union_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "if(!(ref = flatcc_builder_end_table(ctx->ctx))) goto failed;");
     println(out, "if (!(pref = flatcc_builder_table_add_offset(ctx->ctx, id))) goto failed;");
     println(out, "*pref = ref;");
-    println(out, "if (!(ptype = flatcc_builder_table_add(ctx->ctx, id - 1, 1, 1))) goto failed;");
+    println(out, "if (!(ptype = (uint8_t *) flatcc_builder_table_add(ctx->ctx, id - 1, 1, 1))) goto failed;");
     println(out, "*ptype = type;");
     unindent(); println(out, "}");
     println(out, "return buf;");

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -1395,7 +1395,7 @@ static int gen_union_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "if(!(ref = flatcc_builder_end_table(ctx->ctx))) goto failed;");
     println(out, "if (!(pref = flatcc_builder_table_add_offset(ctx->ctx, id))) goto failed;");
     println(out, "*pref = ref;");
-    println(out, "if (!(ptype = (uint8_t *) flatcc_builder_table_add(ctx->ctx, id - 1, 1, 1))) goto failed;");
+    println(out, "if (!(ptype = (uint8_t *)flatcc_builder_table_add(ctx->ctx, id - 1, 1, 1))) goto failed;");
     println(out, "*ptype = type;");
     unindent(); println(out, "}");
     println(out, "return buf;");

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -52,7 +52,7 @@ static void print_type_identifier(fb_output_t *out, const char *name, uint32_t t
     }
     *p = '\0';
     fprintf(out->fp,
-        "#define %s_type_identifier (*((flatbuffers_fid_t *) \"%s\"))\n",
+        "#define %s_type_identifier \"%s\"\n",
         name, buf);
 }
 
@@ -734,7 +734,7 @@ static void gen_pretext(fb_output_t *out)
     if (out->S->file_identifier.type == vt_string) {
         fprintf(out->fp,
             "#undef %sidentifier\n"
-            "#define %sidentifier (*((flatbuffers_fid_t *) \"%.*s\"))\n",
+            "#define %sidentifier \"%.*s\"\n",
             nsc,
             nsc, out->S->file_identifier.s.len, out->S->file_identifier.s.s);
     } else {

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -52,7 +52,7 @@ static void print_type_identifier(fb_output_t *out, const char *name, uint32_t t
     }
     *p = '\0';
     fprintf(out->fp,
-        "#define %s_type_identifier \"%s\"\n",
+        "#define %s_type_identifier (*((flatbuffers_fid_t *) \"%s\"))\n",
         name, buf);
 }
 
@@ -734,7 +734,7 @@ static void gen_pretext(fb_output_t *out)
     if (out->S->file_identifier.type == vt_string) {
         fprintf(out->fp,
             "#undef %sidentifier\n"
-            "#define %sidentifier \"%.*s\"\n",
+            "#define %sidentifier (*((flatbuffers_fid_t *) \"%.*s\"))\n",
             nsc,
             nsc, out->S->file_identifier.s.len, out->S->file_identifier.s.s);
     } else {


### PR DESCRIPTION
The code generated by flatcc could not be compiled cleanly with
C++ compilers, for the following reasons:

 * C++ does not allow implicit casts from `void *` to
   `destination *`. Addressed by adding explicit type-casts where
   such type-conversions occur, or by adding additional type
   information to source types.
 * C++ deprecates implicit casts from string constants to char *'s,
   or to char array types. Addressed by modifying the constant
   exposed by the `%s_identifier` macros to be of the appropriate
   `flatbuffers_fid_t` data type.