### PR TITLE
Silence gcc 7.x warnings about implicit fallthrough

### DIFF
--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -221,13 +221,21 @@ static inline uint64_t flatcc_json_parser_symbol_part_ext(const char *buf, const
 #if 1
     switch (n) {
     case 8: w |= ((uint64_t)buf[7]) << (0 * 8);
+        /* Fall through */
     case 7: w |= ((uint64_t)buf[6]) << (1 * 8);
+        /* Fall through */
     case 6: w |= ((uint64_t)buf[5]) << (2 * 8);
+        /* Fall through */
     case 5: w |= ((uint64_t)buf[4]) << (3 * 8);
+        /* Fall through */
     case 4: w |= ((uint64_t)buf[3]) << (4 * 8);
+        /* Fall through */
     case 3: w |= ((uint64_t)buf[2]) << (5 * 8);
+        /* Fall through */
     case 2: w |= ((uint64_t)buf[1]) << (6 * 8);
+        /* Fall through */
     case 1: w |= ((uint64_t)buf[0]) << (7 * 8);
+        /* Fall through */
     case 0:
         break;
     }

--- a/include/flatcc/portable/pprintint.h
+++ b/include/flatcc/portable/pprintint.h
@@ -184,8 +184,10 @@ static int print_uint16(uint16_t n, char *p)
         switch (k) {
         case 5:
             __print_stage();
+	    /* Fall through */
         case 3:
             __print_stage();
+	    /* Fall through */
         case 1:
             p[-1] = n + '0';
         }
@@ -193,6 +195,7 @@ static int print_uint16(uint16_t n, char *p)
         switch (k) {
         case 4:
             __print_stage();
+	    /* Fall through */
         case 2:
             __print_stage();
         }
@@ -244,12 +247,16 @@ static int print_uint32(uint32_t n, char *p)
         switch (k) {
         case 9:
             __print_stage();
+	    /* Fall through */
         case 7:
             __print_stage();
+	    /* Fall through */
         case 5:
             __print_stage();
+	    /* Fall through */
         case 3:
             __print_stage();
+	    /* Fall through */
         case 1:
             p[-1] = n + '0';
         }
@@ -257,14 +264,19 @@ static int print_uint32(uint32_t n, char *p)
         switch (k) {
         case 10:
             __print_stage();
+	    /* Fall through */
         case 8:
             __print_stage();
+	    /* Fall through */
         case 6:
             __print_stage();
+	    /* Fall through */
         case 4:
             __print_stage();
+	    /* Fall through */
         case 2:
             __print_stage();
+	    /* Fall through */
         }
     }
     return k;
@@ -322,12 +334,16 @@ static int print_uint64(uint64_t n, char *p)
         switch (k) {
         case 19:
             __print_stage();
+	    /* Fall through */
         case 17:
             __print_stage();
+	    /* Fall through */
         case 15:
             __print_stage();
+	    /* Fall through */
         case 13:
             __print_stage();
+	    /* Fall through */
         case 11:
             __print_stage()
             __print_short_stage();
@@ -336,14 +352,19 @@ static int print_uint64(uint64_t n, char *p)
         switch (k) {
         case 20:
             __print_stage();
+	    /* Fall through */
         case 18:
             __print_stage();
+	    /* Fall through */
         case 16:
             __print_stage();
+	    /* Fall through */
         case 14:
             __print_stage();
+	    /* Fall through */
         case 12:
             __print_stage();
+	    /* Fall through */
         case 10:
             __print_stage();
         }

--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -642,7 +642,7 @@ static int get_total_struct_field_count(fb_compound_type_t *ct)
                 count += get_total_struct_field_count(member->type.ct);
                 continue;
             }
-            /* enum fall through. */
+            /* Fall through */
         default:
             ++count;
         }

--- a/src/runtime/json_parser.c
+++ b/src/runtime/json_parser.c
@@ -130,7 +130,8 @@ descend:
     while (buf != end && *buf <= 0x20) {
         switch (*buf) {
         case 0x0d: buf += (end - buf > 1 && buf[1] == 0x0a);
-            /* Fall through consuming following LF or treating CR as LF. */
+            /* Fall through */
+            /* Consume following LF or treating CR as LF. */
         case 0x0a: ++ctx->line; ctx->line_start = ++buf; continue;
         case 0x09: ++buf; continue;
         case 0x20: goto again; /* Don't consume here, sync with power of 2 spaces. */


### PR DESCRIPTION
Closes dvidelabs/flatcc#58.