### PR TITLE
Add cast to (char *) to avoid -fpermissive error when using C++

### DIFF
--- a/include/flatcc/portable/paligned_alloc.h
+++ b/include/flatcc/portable/paligned_alloc.h
@@ -128,7 +128,7 @@ static inline void *__portable_aligned_alloc(size_t alignment, size_t size)
 
 static inline void __portable_aligned_free(void *p)
 {
-    char *raw = ((void **)p)[-1];
+    char *raw = (char*)((void **)p)[-1];
 
     free(raw);
 }

--- a/include/flatcc/portable/pbase64.h
+++ b/include/flatcc/portable/pbase64.h
@@ -155,7 +155,7 @@ static int base64_encode(uint8_t *dst, const uint8_t *src, size_t *dst_len, size
     const uint8_t *T;
     uint8_t *dst_base = dst;
     int pad = mode & base64_enc_modifier_padding;
-    size_t len;
+    size_t len = 0;
     int ret = BASE64_EMODE;
 
     if (!src_len) {


### PR DESCRIPTION
Avoid the following error when using flatcc from C++ via this PR:
```
In file included from /X/flatcc/include/flatcc/portable/pstdalign.h:60:0,
                 from /X/flatcc/include/flatcc/flatcc_flatbuffers.h:20,
                 from /X/flatcc/include/flatcc/flatcc_builder.h:64,
                 from /X/src/json_to_flatbuffers_converter.inl:9,
                 from /X/src/json_to_flatbuffers_converter.h:31,
                 from /X/curl_test_task.cpp:3:
/X/flatcc/include/flatcc/portable/paligned_alloc.h: In function 'void __portable_aligned_free(void*)':
/X/flatcc/include/flatcc/portable/paligned_alloc.h:131:32: error: invalid conversion from 'void*' to 'char*' [-fpermi]
     char *raw = ((void **)p)[-1];
```