### PR TITLE
[WIP] Add '#ifdef __cplusplus' guards 

### DIFF
--- a/include/flatcc/flatcc.h
+++ b/include/flatcc/flatcc.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_H
 #define FLATCC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This is the primary `flatcc` interface when compiling `flatcc` as a
  * library. Functions and types in the this interface will be kept
@@ -250,6 +254,10 @@ void flatcc_destroy_context(flatcc_context_t ctx);
 
 #ifdef _MSC_VER
 #pragma warning(pop)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* FLATCC_H */

--- a/include/flatcc/flatcc_accessors.h
+++ b/include/flatcc/flatcc_accessors.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_ACCESSORS
 #define FLATCC_ACCESSORS
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef UINT8_MAX
 #include <stdint.h>
 #endif
@@ -85,5 +89,9 @@ __flatcc_define_basic_integer_accessors(NS, int32, int32_t, 32, E)          \
 __flatcc_define_basic_integer_accessors(NS, int64, int64_t, 64, E)          \
 __flatcc_define_basic_real_accessors(NS, float, float, 32, E)               \
 __flatcc_define_basic_real_accessors(NS, double, double, 64, E)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_ACCESSORS */

--- a/include/flatcc/flatcc_alloc.h
+++ b/include/flatcc/flatcc_alloc.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_ALLOC_H
 #define FLATCC_ALLOC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * These allocation abstractions are __only__ for runtime libraries.
  *
@@ -111,6 +115,10 @@ static inline void __flatcc_aligned_free(void *p)
 
 #ifndef FLATCC_ALIGNED_FREE
 #define FLATCC_ALIGNED_FREE(p) aligned_free(p)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* FLATCC_ALLOC_H */

--- a/include/flatcc/flatcc_builder.h
+++ b/include/flatcc/flatcc_builder.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_BUILDER_H
 #define FLATCC_BUILDER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Library for building untyped FlatBuffers. Intended as a support
  * library for generated C code to produce typed builders, but might
@@ -1754,5 +1758,9 @@ void flatcc_builder_aligned_free(void *p);
  * Other emitters have custom interfaces for reaching their content.
  */
 void *flatcc_builder_copy_buffer(flatcc_builder_t *B, void *buffer, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_BUILDER_H */

--- a/include/flatcc/flatcc_emitter.h
+++ b/include/flatcc/flatcc_emitter.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_EMITTER_H
 #define FLATCC_EMITTER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Default implementation of a flatbuilder emitter.
  *
@@ -203,5 +207,9 @@ void *flatcc_emitter_copy_buffer(flatcc_emitter_t *E, void *buf, size_t size);
 int flatcc_emitter(void *emit_context,
         const flatcc_iovec_t *iov, int iov_count,
         flatbuffers_soffset_t offset, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_EMITTER_H */

--- a/include/flatcc/flatcc_endian.h
+++ b/include/flatcc/flatcc_endian.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_ENDIAN_H
 #define FLATCC_ENDIAN_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This file provides helper macros to define type-specific macros and
  * inline functions that convert between stored data and native data
@@ -112,6 +116,10 @@
 
 #ifndef flatbuffers_is_native_be
 #define flatbuffers_is_native_be() (!flatbuffers_is_native_pe())
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* FLATCC_ENDIAN_H */

--- a/include/flatcc/flatcc_flatbuffers.h
+++ b/include/flatcc/flatcc_flatbuffers.h
@@ -9,6 +9,10 @@
 #ifndef FLATCC_FLATBUFFERS_H
 #define FLATCC_FLATBUFFERS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef flatcc_flatbuffers_defined
 #define flatcc_flatbuffers_defined
 
@@ -39,5 +43,9 @@
 #endif
 
 #endif /* flatcc_flatbuffers_defined */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_FLATBUFFERS_H */

--- a/include/flatcc/flatcc_identifier.h
+++ b/include/flatcc/flatcc_identifier.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_IDENTIFIER_H
 #define FLATCC_IDENTIFIER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef FLATCC_FLATBUFFERS_H
 #error "include via flatcc/flatcc_flatbuffers.h"
 #endif
@@ -111,5 +115,9 @@ static inline uint32_t flatbuffers_disperse_type_hash(flatbuffers_thash_t type_h
 /* We have hardcoded assumptions about identifier size. */
 static_assert(sizeof(flatbuffers_fid_t) == 4, "unexpected file identifier size");
 static_assert(sizeof(flatbuffers_thash_t) == 4, "unexpected type hash size");
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_IDENTIFIER_H */

--- a/include/flatcc/flatcc_iov.h
+++ b/include/flatcc/flatcc_iov.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_IOV_H
 #define FLATCC_IOV_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 
 /*
@@ -19,5 +23,9 @@ struct flatcc_iovec {
  * always be a relatively small number.
  */
 #define FLATCC_IOV_COUNT_MAX 8
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_IOV_H */

--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_JSON_PARSE_H
 #define FLATCC_JSON_PARSE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * JSON RFC:
  * http://www.ietf.org/rfc/rfc4627.txt?number=4627
@@ -868,4 +872,9 @@ int flatcc_json_parser_struct_as_root(flatcc_builder_t *B, flatcc_json_parser_t 
         flatcc_json_parser_struct_f *parser);
 
 #include "flatcc/portable/pdiagnostic_pop.h"
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* FLATCC_JSON_PARSE_H */

--- a/include/flatcc/flatcc_json_printer.h
+++ b/include/flatcc/flatcc_json_printer.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_JSON_PRINTER_H
 #define FLATCC_JSON_PRINTER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Definitions for default implementation, do not assume these are
  * always valid.
@@ -689,5 +693,9 @@ void flatcc_json_printer_union_struct(flatcc_json_printer_t *ctx,
 
 void flatcc_json_printer_union_string(flatcc_json_printer_t *ctx,
         flatcc_json_printer_union_descriptor_t *ud);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_JSON_PRINTER_H */

--- a/include/flatcc/flatcc_portable.h
+++ b/include/flatcc/flatcc_portable.h
@@ -1,4 +1,14 @@
 #ifndef FLATCC_PORTABLE_H
 #define FLATCC_PORTABLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "flatcc/portable/portable_basic.h"
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* FLATCC_PORTABLE_H */

--- a/include/flatcc/flatcc_rtconfig.h
+++ b/include/flatcc/flatcc_rtconfig.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_RTCONFIG_H
 #define FLATCC_RTCONFIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 /* Include portability layer here since all other files depend on it. */
 #ifdef FLATCC_PORTABLE
@@ -149,6 +153,10 @@
  */
 #ifndef FLATCC_JSON_PARSE_WIDE_SPACE
 #define FLATCC_JSON_PARSE_WIDE_SPACE 0
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* FLATCC_RTCONFIG_H */

--- a/include/flatcc/flatcc_types.h
+++ b/include/flatcc/flatcc_types.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_TYPES_H
 #define FLATCC_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 
 #ifndef UINT8_MAX
@@ -85,5 +89,9 @@ static const flatbuffers_bool_t flatbuffers_false = FLATBUFFERS_FALSE;
 typedef char flatbuffers_fid_t[FLATBUFFERS_IDENTIFIER_SIZE];
 
 #endif /* flatbuffers_types_defined */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_TYPES_H */

--- a/include/flatcc/flatcc_unaligned.h
+++ b/include/flatcc/flatcc_unaligned.h
@@ -1,8 +1,16 @@
 #ifndef FLATCC_UNLIGNED_H
 #define FLATCC_UNLIGNED_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "flatcc/portable/punaligned.h"
 
 #define FLATCC_ALLOW_UNALIGNED_ACCESS PORTABLE_UNALIGNED_ACCESS
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_UNLIGNED_H */

--- a/include/flatcc/flatcc_verifier.h
+++ b/include/flatcc/flatcc_verifier.h
@@ -1,6 +1,10 @@
 #ifndef FLATCC_VERIFIER_H
 #define FLATCC_VERIFIER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Runtime support for verifying flatbuffers.
  *
@@ -227,5 +231,9 @@ int flatcc_verify_union_vector_field(flatcc_table_verifier_descriptor_t *td,
 int flatcc_verify_union_table(flatcc_union_verifier_descriptor_t *ud, flatcc_table_verifier_f *tvf);
 int flatcc_verify_union_struct(flatcc_union_verifier_descriptor_t *ud, size_t size, uint16_t align);
 int flatcc_verify_union_string(flatcc_union_verifier_descriptor_t *ud);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FLATCC_VERIFIER_H */

--- a/include/flatcc/flatcc_version.h
+++ b/include/flatcc/flatcc_version.h
@@ -1,6 +1,14 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define FLATCC_VERSION_TEXT "0.5.1-pre"
 #define FLATCC_VERSION_MAJOR 0
 #define FLATCC_VERSION_MINOR 5
 #define FLATCC_VERSION_PATCH 1
 /* 1 or 0 */
 #define FLATCC_VERSION_RELEASED 0
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/flatcc/support/cdump.h
+++ b/include/flatcc/support/cdump.h
@@ -1,6 +1,10 @@
 #ifndef CDUMP_H
 #define CDUMP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdio.h>
 
 /* Generates a constant a C byte array. */
@@ -27,5 +31,9 @@ static void cdump(char *name, void *addr, size_t len, FILE *fp) {
     }
     fprintf(fp, "\n};\n");
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CDUMP_H */

--- a/include/flatcc/support/elapsed.h
+++ b/include/flatcc/support/elapsed.h
@@ -1,6 +1,10 @@
 #ifndef ELAPSED_H
 #define ELAPSED_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdio.h>
 
 /* Based on http://stackoverflow.com/a/8583395 */
@@ -61,5 +65,9 @@ static int show_benchmark(const char *descr, double t1, double t2, size_t size, 
     }
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ELAPSED_H */

--- a/include/flatcc/support/hexdump.h
+++ b/include/flatcc/support/hexdump.h
@@ -1,6 +1,10 @@
 #ifndef HEXDUMP_H
 #define HEXDUMP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdio.h>
 
 /* Based on: http://stackoverflow.com/a/7776146 */
@@ -48,5 +52,9 @@ static void hexdump(char *desc, void *addr, size_t len, FILE *fp) {
     // And print the final ASCII bit.
     fprintf(fp, "  %s\n", buff);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HEXDUMP_H */

--- a/include/flatcc/support/readfile.h
+++ b/include/flatcc/support/readfile.h
@@ -1,6 +1,10 @@
 #ifndef READFILE_H
 #define READFILE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -51,5 +55,9 @@ fail:
     *size_out = size;
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* READFILE_H */


### PR DESCRIPTION
Wrap public header files in `#ifdef _cplusplus` guards to allow `#include`s from other C++ or C translation units.

Also add support to codegen_c sources to add include guards to all generated headers.

This helps me when using flatcc from C++, as I do not need to wrap the flatcc header includes in `extern "C"`.

As a first attempt, I added it manually to (almost all) header files in `include`, just after the existing `#ifdef FILE_H` include guards (if present). This generates files such as I modify them by hand, and for my purposes appears to work fine.