### PR TITLE
Fix incorrect void * in generated _as_root JSON parsers

### DIFF
--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -1477,7 +1477,7 @@ static int gen_table_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "");
     println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const void *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
     println(out, "{"); indent();
-    println(out, "return flatcc_json_parser_table_as_root(B, ctx, buf, bufsiz, flags, fid, %s_parse_json_table);",
+    println(out, "return flatcc_json_parser_table_as_root(B, ctx, (char*)buf, bufsiz, flags, fid, %s_parse_json_table);",
             snt.text);
     unindent(); println(out, "}");
     println(out, "");

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -1371,7 +1371,7 @@ static int gen_struct_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "");
     /* TODO: */
 #if 0
-    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const void *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
+    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const char *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
     println(out, "{"); indent();
     println(out, "return flatcc_json_parser_struct_as_root(B, ctx, buf, bufsiz, flags, fid, %s_parse_json_struct);",
             snt.text);
@@ -1475,9 +1475,9 @@ static int gen_table_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "return flatcc_json_parser_set_error(ctx, buf, end, flatcc_json_parser_error_runtime);");
     unindent(); println(out, "}");
     println(out, "");
-    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const void *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
+    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const char *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
     println(out, "{"); indent();
-    println(out, "return flatcc_json_parser_table_as_root(B, ctx, (char*)buf, bufsiz, flags, fid, %s_parse_json_table);",
+    println(out, "return flatcc_json_parser_table_as_root(B, ctx, buf, bufsiz, flags, fid, %s_parse_json_table);",
             snt.text);
     unindent(); println(out, "}");
     println(out, "");


### PR DESCRIPTION
to support compiling the json_parser header with a C++ compiler.