### PR TITLE
Some more typecasts to satisfy the latest version of the clang++ compiler

### DIFF
--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -231,7 +231,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline int V ## _truncate(NS ## builder_t *B, size_t len)\\\n"
         "{ return flatcc_builder_truncate_union_vector(B, len); }\\\n"
         "static inline TN ## _union_ref_t *V ## _edit(NS ## builder_t *B)\\\n"
-        "{ return flatcc_builder_union_vector_edit(B); }\\\n"
+        "{ return (TN ## _union_ref_t *) flatcc_builder_union_vector_edit(B); }\\\n"
         "static inline size_t V ## _reserved_len(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_union_vector_count(B); }\\\n"
         "static inline TN ## _union_ref_t *V ## _push(NS ## builder_t *B, const TN ## _union_ref_t ref)\\\n"

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -215,7 +215,7 @@ static void gen_union(fb_output_t *out)
         "  if (u.type == 0) return u;\\\n"
         "  u.value = NS ## generic_vec_at(uv.value, i); return u; }\\\n"
         "static inline NS ## string_t T ## _union_vec_at_as_string(T ## _union_vec_t uv, size_t i)\\\n"
-        "{ return NS ## generic_vec_at_as_string(uv.value, i); }\\\n"
+        "{ return (NS ## string_t) NS ## generic_vec_at_as_string(uv.value, i); }\\\n"
         "\n",
         nsc);
     fprintf(out->fp,


### PR DESCRIPTION
Adding these typecasts prevents the more recent versions of the clang++ compiler from complaining.