### PR TITLE
Fix scripts/_user_build.in

### DIFF
--- a/scripts/_user_build.in
+++ b/scripts/_user_build.in
@@ -15,8 +15,7 @@ mkdir -p generated
 
 cd build
 
-PORTABLE=
-if [[ "$FLATCC_PORTABLE" -eq "yes" ]]; then
+if [[ "$FLATCC_PORTABLE" = "yes" ]]; then
     CFLAGS="$CFLAGS -DFLATCC_PORTABLE"
 fi
 
@@ -29,5 +28,5 @@ ${ROOT}/bin/flatcc -a -o ${ROOT}/generated ${ROOT}/src/*.fbs
 echo "building '$NAME' for debug"
 $CC $CFLAGS $CFLAGS_DEBUG ${ROOT}/src/*.c ${ROOT}/lib/libflatccrt_d.a -o ${NAME}_d
 
-echo "building '$NAME' for relase"
+echo "building '$NAME' for release"
 $CC $CFLAGS $CFLAGS_RELEASE ${ROOT}/src/*.c ${ROOT}/lib/libflatccrt.a -o ${NAME}


### PR DESCRIPTION
Hi,

I changed the `if` condition because it was always true: The `-eq` causes the strings to be interpreted as integers if possible.

For proper comparison of strings use `=`.

Also removed `PORTABLE` variable because it wasn't used in the whole project (correct me if I am wrong).

And finally corrected a typo.