### PR TITLE
Fix scripts/test.sh in debug mode

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ ROOT=`pwd`
 DBGDIR=$ROOT/build/Debug
 RELDIR=$ROOT/build/Release
 
-if [ "$1" == "--debug" ]; then
+if [ "$1" = "--debug" ]; then
     DEBUG=$1
     echo "running debug build"
     shift


### PR DESCRIPTION
Hi,

I noticed that passing tests in debug mode `(scripts/test.sh --debug)` was not working properly: it passes debug and release tests instead of only the first one. In the output of the command the first line is:

`scripts/test.sh: 12: [: --debug: unexpected operator`.

This is due to the `==` operator which is s a bash-specific alias for `=` but is not supported in POSIX sh. To fix it, we need to change the shebang to use bash or use the `=` operator.

I prefer to change the operator instead of the shebang because using sh give more portability advantages. 