### PR TITLE
Fix build with gcc-8

### DIFF
--- a/include/flatcc/reflection/flatbuffers_common_reader.h
+++ b/include/flatcc/reflection/flatbuffers_common_reader.h
@@ -433,7 +433,7 @@ static inline T N ## _ ## NK(N ## _struct_t t) { return t ? &(t->NK) : 0; }
 /* If fid is null, the function returns true without testing as buffer is not expected to have any id. */
 static inline int flatbuffers_has_identifier(const void *buffer, const char *fid)
 { flatbuffers_thash_t id, id2 = 0; if (fid == 0) { return 1; };
-  strncpy((char *)&id2, fid, sizeof(id2));
+  memcpy(&id2, fid, sizeof(id2));
   /* Identifier strings are always considered little endian. */
   id2 = __flatbuffers_thash_cast_from_le(id2);
   id = __flatbuffers_thash_read_from_pe(((flatbuffers_uoffset_t *)buffer) + 1);

--- a/src/runtime/json_printer.c
+++ b/src/runtime/json_printer.c
@@ -1020,7 +1020,7 @@ static int accept_header(flatcc_json_printer_t * ctx,
         return 0;
     }
     if (fid != 0) {
-        strncpy((char *)&id2, fid, FLATBUFFERS_IDENTIFIER_SIZE);
+        memcpy(&id2, fid, FLATBUFFERS_IDENTIFIER_SIZE);
         id2 = __flatbuffers_thash_cast_from_le(id2);
         id = __flatbuffers_thash_read_from_pe((uint8_t *)buf + offset_size);
         if (!(id2 == 0 || id == id2)) {

--- a/src/runtime/verifier.c
+++ b/src/runtime/verifier.c
@@ -111,7 +111,7 @@ static inline uoffset_t read_uoffset(const void *p, uoffset_t base)
 static inline thash_t read_thash_identifier(const char *identifier)
 {
     flatbuffers_thash_t id = 0;
-    strncpy((char *)&id, identifier, sizeof(id));
+    memcpy(&id, identifier, sizeof(id));
     return __flatbuffers_thash_cast_from_le(id);
 }
 


### PR DESCRIPTION
gcc 8 enables a warning about strncpy that might leave the destination
string without a terminating null character. This breaks the build:

In function ‘read_thash_identifier’,
    inlined from ‘flatcc_verify_buffer_header’ at .../src/runtime/verifier.c:468:15:
.../src/runtime/verifier.c:114:5: error: ‘strncpy’ specified bound 4 equals destination size [-Werror=stringop-truncation]
     strncpy((char *)&id, identifier, sizeof(id));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

.../src/runtime/json_printer.c: In function ‘accept_header’:
.../src/runtime/json_printer.c:1023:9: error: ‘strncpy’ specified bound 4 equals destination size [-Werror=stringop-truncation]
         strncpy((char *)&id2, fid, FLATBUFFERS_IDENTIFIER_SIZE);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

.../src/compiler/codegen_schema.c: In function ‘flatbuffers_has_identifier.constprop’:
.../include/flatcc/reflection/flatbuffers_common_reader.h:436:3: error: ‘strncpy’ output truncated before terminating nul copying 4 bytes from a string of the same length [-Werror=stringop-truncation]
   strncpy((char *)&id2, fid, sizeof(id2));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Use memcpy instead, since memcpy is not expected to leave a null
terminator.