### PR TITLE
Added a failing test inside monster_test for a crash in _pick.

### DIFF
--- a/backtrace.txt
+++ b/backtrace.txt
@@ -1,0 +1,17 @@
+Program received signal SIGSEGV, Segmentation fault.
+
+Stack
+[0] from 0x00007ffff7a91f78
+[1] from 0x00007ffff7a93ae0 in malloc+-3531168
+[2] from 0x00007ffff7a83142 in vasprintf+34
+[3] from 0x00007ffff7a65597 in asprintf+135
+[4] from 0x00007ffff7a40b52
+[5] from 0x00007ffff7a40ca2 in __assert_fail+66
+[6] from 0x000000000042c9b3 in _create_offset_vector_direct+852 at /home/dev/src/flatcc/src/runtime/builder.c:1468
+[7] from 0x000000000042ca1d in flatcc_builder_create_offset_vector_direct+45 at /home/dev/src/flatcc/src/runtime/builder.c:1478
+[8] from 0x000000000042ca7a in flatcc_builder_end_offset_vector+91 at /home/dev/src/flatcc/src/runtime/builder.c:1486
+[9] from 0x000000000041b236 in PickTest_MA_vec_clone+244 at /home/dev/src/flatcc/build/lindebug/test/monster_test/generated/pick_test_builder.h:54
+[10] from 0x000000000041fc40 in PickTest_State_ma_clone+35 at /home/dev/src/flatcc/build/lindebug/test/monster_test/generated/pick_test_builder.h:492
+[11] from 0x000000000041fc8c in PickTest_State_ma_pick+58 at /home/dev/src/flatcc/build/lindebug/test/monster_test/generated/pick_test_builder.h:492
+[12] from 0x00000000004247b1 in test_pick_copy+4454 at /home/dev/src/flatcc/test/monster_test/monster_test.c:1203
+[13] from 0x0000000000428a2e in main+78 at /home/dev/src/flatcc/test/monster_test/monster_test.c:2856

--- a/cmake-lin.sh
+++ b/cmake-lin.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#export CC=clang
+#export CXX=clang++
+
+# Note: flatcc's cmake seems to pretty much ignore all the standard cmake options, so we end up with
+#       everything in lib/, include/, etc. rather than build/linux64.
+CMAKE_CMD='cmake -DFLATCC_DEBUG_VERIFY=1 -D CMAKE_INSTALL_PREFIX="../linux64" -G "Unix Makefiles" -D CMAKE_DEBUG_POSTFIX="_debug"'
+
+mkdir -p build/lindebug
+cd build/lindebug
+eval $CMAKE_CMD -D CMAKE_BUILD_TYPE="Debug" ../..
+make -j7
+cd ../..
+
+#mkdir -p build/linrelease
+#cd build/linrelease
+#eval $CMAKE_CMD -D CMAKE_BUILD_TYPE="Release" ../..
+#make -j7
+#cd ../..

--- a/test/monster_test/CMakeLists.txt
+++ b/test/monster_test/CMakeLists.txt
@@ -11,7 +11,8 @@ add_custom_command (
     TARGET gen_monster_test
     COMMAND cmake -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/monster_test.fbs"
-    DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
+    COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/pick_test.fbs"
+    DEPENDS flatcc_cli "${FBS_DIR}/pick_test.fbs" "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )
 add_executable(monster_test monster_test.c)
 add_dependencies(monster_test gen_monster_test)

--- a/test/monster_test/pick_test.fbs
+++ b/test/monster_test/pick_test.fbs
@@ -1,0 +1,127 @@
+namespace PickTest;
+
+struct Vec3 {
+  a:float;
+  b:float;
+  c:float;
+}
+
+table MAParams
+{
+  aa                  : ubyte =   0 (id: 0);
+  bb                  : ubyte =   0 (id: 1);
+  cc                  : ubyte =   0 (id: 2);
+  x1                  : ubyte =   0 (id: 3);
+  x2                  : ubyte =   0 (id: 4);
+  x3                  : ubyte =   0 (id: 5);
+  x4                  : ubyte =   0 (id: 6);
+  x5                  : ubyte =   0 (id: 7);
+  x6                  : ubyte =   0 (id: 8);
+  x7                  : ubyte =   0 (id: 9);
+  x8                  : ubyte =   0 (id:10);
+  x9                  : ubyte =   0 (id:11);
+  y1                  : ubyte =   0 (id:12);
+  y2                  : ubyte =   0 (id:13);
+  y3                  : ubyte =   0 (id:14);
+  y4                  : ubyte =   0 (id:15);
+  y5                  : ubyte =   0 (id:16);
+  y6                  : ubyte =   0 (id:17);
+  y7                  : ubyte =   0 (id:18);
+  y8                  : ubyte =   0 (id:19);
+  y9                  : ubyte =   0 (id:20);
+  z0                  : ubyte =   0 (id:21);
+  z1                  : ubyte =   0 (id:22);
+  z2                  : ubyte =   0 (id:23);
+  z3                  : ubyte =   0 (id:24);
+  z4                  : ubyte =   0 (id:25);
+  z5                  : ubyte =   0 (id:26);
+  z6                  : ubyte =   0 (id:27);
+  z7                  : ubyte =   0 (id:28);
+  z8                  : ubyte =   0 (id:29);
+  z9                  : ubyte =   0 (id:30);
+  k0                  : ubyte =   0 (id:31);
+  k1                  : ubyte =   0 (id:32);
+  k2                  : ubyte =   0 (id:33);
+  k3                  : ubyte =   0 (id:34);
+  k4                  : ubyte =   0 (id:35);
+  k5                  : ubyte =   0 (id:36);
+  k6                  : ubyte =   0 (id:37);
+  k7                  : ubyte =   0 (id:38);
+  k8                  : ubyte =   0 (id:39);
+  k9                  : ubyte =   0 (id:40);
+  j0                  : ubyte =   0 (id:41);
+  j1                  : ubyte =   0 (id:42);
+  j2                  : ubyte =   0 (id:43);
+  j3                  : ubyte =   0 (id:44);
+  j4                  : ubyte =   0 (id:45);
+  j5                  : ubyte =   0 (id:46);
+  j6                  : ubyte =   0 (id:47);  // <--- XXX: If I remove a few fields near the end of this table, the crash changes from being in _create_offset_vector_direct
+}                                             // to being in flatcc_builder_end_table/flatcc_builder_create_table instead (which are also called from
+                                              // various _clone/_pick functions further up the stack. Probably the same issue, but worth pointing out.
+table TA                                      // The amount of fields I need to comment out to get this behavior seems to vary slightly, but usually 3-4 does the trick.
+{
+  pathA           : string              (id:  0);
+  hashA           : ulong          = 0  (id:  1);
+  pathB           : string              (id:  2);
+  hashB           : ulong          = 0  (id:  3);
+  pathC           : string              (id:  4);
+  hashC           : ulong          = 0  (id:  5);
+  pathD           : string              (id:  6);
+  hashD           : ulong          = 0  (id:  7);
+  pathE           : string              (id:  8);
+  hashE           : ulong          = 0  (id:  9);
+  pathF           : string              (id: 10);
+  hashF           : ulong          = 0  (id: 11);
+  pathG           : string              (id: 12);
+  hashG           : ulong          = 0  (id: 13);
+  pathH           : string              (id: 14);
+  hashH           : ulong          = 0  (id: 15);
+  pathJ           : string              (id: 16);
+  hashJ           : ulong          = 0  (id: 17);
+  pathK           : string              (id: 18);
+  hashK           : ulong          = 0  (id: 19);
+}
+
+table MA
+{
+  matHash            : ulong          = 0  (id:  0);
+  params             : MAParams            (id:  1);
+  ta                 : TA                  (id:  2);
+}
+
+table WSS
+{
+  scale         : float  = 1.0 (id: 0);
+}
+
+table UState
+{
+  wss        : WSS       (id: 0);
+}
+
+table TVV
+{
+  wss        : WSS         (id: 0);
+}
+
+table State
+{
+  cp                   : Vec3                         (id:  0);
+  ct                   : Vec3                         (id:  1);
+  cpp                 : Vec3                         (id:  2);
+  wbc                      : Vec3                         (id:  3);
+  eev                      : string                       (id:  4);
+  bgc                      : Vec3                         (id:  5);
+  wfc                      : Vec3                         (id:  6);
+  nvv                      : [ulong]                      (id:  7);
+  uState                   : UState                       (id:  8);
+  tvv                      : [TVV]                        (id:  9);
+  wOrder                   : [ushort]                     (id: 10);
+  ma                       : [MA]                         (id: 11);
+}
+
+file_identifier "PICK";
+
+root_type State;
+
+/* vim: set sw=2 ts=2 expandtab: */


### PR DESCRIPTION
To repro, compile and run monster_test_d.

See backtrace.txt and search for XXX inside of the following files
for important notes regarding the issue:
test/monster_test/monster_test.c
test/monster_test/pick_test.fbs

Perhaps this is an incorrect library usage somewhere, but it certainly seems odd.

I've commented out all other tests for now, mainly to simplify my workflow while working on this issue, but also because the rest of the monster tests weren't playing nice with this one when I tried to compile everything together.