### PR TITLE
Added a failing test for the int key sort issue.

### DIFF
--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -1153,7 +1153,7 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
                         nsc, snt.text, n, s, tname_ns, tname);
                 if (out->opts->cgen_sort) {
                     fprintf(out->fp,
-                        "__%sdefine_sort_by_scalar_field(%s, %.*s, %s%s, %s_t)\n",
+                        "__%sdefine_struct_sort_by_scalar_field(%s, %.*s, %s%s, %s_t)\n",
                         nsc, snt.text, n, s, tname_ns, tname, snt.text);
                 }
                 if (!already_has_key) {
@@ -1196,7 +1196,7 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
                             nsc, snt.text, n, s, snref.text);
                     if (out->opts->cgen_sort) {
                         fprintf(out->fp,
-                            "__%sdefine_sort_by_scalar_field(%s, %.*s, %s_enum_t, %s_t)\n",
+                            "__%sdefine_struct_sort_by_scalar_field(%s, %.*s, %s_enum_t, %s_t)\n",
                             nsc, snt.text, n, s, snref.text, snt.text);
                     }
                     if (!already_has_key) {
@@ -1489,8 +1489,8 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                         nsc, snt.text, n, s, tname_ns, tname);
                 if (out->opts->cgen_sort) {
                     fprintf(out->fp,
-                        "__%sdefine_sort_by_scalar_field(%s, %.*s, %s%s, %suoffset_t)\n",
-                        nsc, snt.text, n, s, tname_ns, tname, nsc);
+                        "__%sdefine_table_sort_by_scalar_field(%s, %.*s, %s%s)\n",
+                        nsc, snt.text, n, s, tname_ns, tname);
                 }
                 if (!already_has_key) {
                     fprintf(out->fp,
@@ -1596,8 +1596,8 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                             nsc, snt.text, n, s, snref.text);
                     if (out->opts->cgen_sort) {
                         fprintf(out->fp,
-                                "__%sdefine_sort_by_scalar_field(%s, %.*s, %s_enum_t, %suoffset_t)\n",
-                                nsc, snt.text, n, s, snref.text, nsc);
+                                "__%sdefine_table_sort_by_scalar_field(%s, %.*s, %s_enum_t)\n",
+                                nsc, snt.text, n, s, snref.text);
                     }
                     if (!already_has_key) {
                         fprintf(out->fp,

--- a/src/compiler/codegen_c_sort.c
+++ b/src/compiler/codegen_c_sort.c
@@ -77,8 +77,8 @@ int gen_sort(fb_output_t *out)
         "#define __%sstring_diff(x, y) __%sstring_n_cmp((x), (const char *)(y), %sstring_len(y))\n",
         out->nsc, out->nsc, out->nsc, out->nsc);
     fprintf(out->fp,
-        "#define __%sscalar_swap(vec, a, b, TE) { TE x__tmp = vec[b]; vec[b] = vec[a]; vec[a] = x__tmp; }\n"
-        "#define __%sstring_swap(vec, a, b, TE)\\\n"
+        "#define __%svalue_swap(vec, a, b, TE) { TE x__tmp = vec[b]; vec[b] = vec[a]; vec[a] = x__tmp; }\n"
+        "#define __%suoffset_swap(vec, a, b, TE)\\\n"
         "{ TE ta__tmp, tb__tmp, d__tmp;\\\n"
         "  d__tmp = (TE)((a - b) * sizeof(vec[0]));\\\n"
         "  ta__tmp =  __flatbuffers_uoffset_read_from_pe(vec + b) - d__tmp;\\\n"
@@ -87,12 +87,28 @@ int gen_sort(fb_output_t *out)
         "  __flatbuffers_uoffset_write_to_pe(vec + b, tb__tmp); }\n",
         out->nsc, out->nsc);
     fprintf(out->fp,
-        "#define __%sdefine_sort_by_scalar_field(N, NK, TK, TE)\\\n"
-        "  __%sdefine_sort_by_field(N, NK, TK, TE, __%sscalar_diff, __%sscalar_swap)\n",
+            "#define __%sscalar_swap(vec, a, b, TE) __%svalue_swap(vec, a, b, TE)\n",
+        out->nsc, out->nsc);
+    fprintf(out->fp,
+            "#define __%sstring_swap(vec, a, b, TE) __%suoffset_swap(vec, a, b, TE)\n",
+        out->nsc, out->nsc);
+    fprintf(out->fp,
+            "#define __%sstruct_swap(vec, a, b, TE) __%svalue_swap(vec, a, b, TE)\n",
+        out->nsc, out->nsc);
+    fprintf(out->fp,
+            "#define __%stable_swap(vec, a, b, TE) __%suoffset_swap(vec, a, b, TE)\n",
+        out->nsc, out->nsc);
+    fprintf(out->fp,
+        "#define __%sdefine_struct_sort_by_scalar_field(N, NK, TK, TE)\\\n"
+        "  __%sdefine_sort_by_field(N, NK, TK, TE, __%sscalar_diff, __%sstruct_swap)\n",
         out->nsc, out->nsc, out->nsc, out->nsc);
     fprintf(out->fp,
+        "#define __%sdefine_table_sort_by_scalar_field(N, NK, TK)\\\n"
+        "  __%sdefine_sort_by_field(N, NK, TK, %suoffset_t, __%sscalar_diff, __%stable_swap)\n",
+        out->nsc, out->nsc, out->nsc, out->nsc, out->nsc);
+    fprintf(out->fp,
         "#define __%sdefine_sort_by_string_field(N, NK)\\\n"
-        "  __%sdefine_sort_by_field(N, NK, %sstring_t, %suoffset_t, __%sstring_diff, __%sstring_swap)\n",
+        "  __%sdefine_sort_by_field(N, NK, %sstring_t, %suoffset_t, __%sstring_diff, __%suoffset_swap)\n",
         out->nsc, out->nsc, out->nsc, out->nsc, out->nsc, out->nsc);
     fprintf(out->fp,
         "#define __%sdefine_scalar_sort(N, T) __%sdefine_sort(N, T, T, __%sscalar_diff, __%sscalar_swap)\n",

--- a/test/monster_test/monster_test.fbs
+++ b/test/monster_test/monster_test.fbs
@@ -240,6 +240,7 @@ table Monster {
   vector_of_doubles:[double] (id:33);
   parent_namespace_test:InParentNamespace (id:34);
   testbase64:TestBase64 (id:35);
+  intkey:uint64 (id:36, key);
 }
 
 table TypeAliases {


### PR DESCRIPTION
This PR adds a failing test for what might be an issue with sorting on integer keys.
This uses a uint64 type as the key in the schema, but I've found that it also fails on uint32/uint16/uint8 as well.

To repro, run `scripts/test.sh  --debug`. This should be printed:
```
          3 - monster_test (SEGFAULT)
```

The backtrace looks like this:
```
#0  0x000000000040395f in __flatbuffers_voffset_read_from_pe (p=0xffffffff93f74065) at ../../include/flatcc/flatcc_endian.h:91
#1  0x000000000040ab53 in MyGame_Example_Monster_intkey_get (t__tmp=0x63b5ac) at test/monster_test/generated/monster_test_reader.h:810
#2  0x000000000040ae59 in __MyGame_Example_Monster_sort_by_intkey__heap_sift_down (vec__tmp=0x63b58c, start__tmp=0, end__tmp=2) at test/monster_test/generated/monster_test_reader.h:814
#3  0x000000000040b009 in __MyGame_Example_Monster_sort_by_intkey__heap_sort (vec__tmp=0x63b58c) at test/monster_test/generated/monster_test_reader.h:814
#4  0x000000000040b02a in MyGame_Example_Monster_vec_sort_by_intkey (vec__tmp=0x63b58c) at test/monster_test/generated/monster_test_reader.h:814
#5  0x000000000041a4c8 in test_sort_find_by_intfield (B=0x7fffffffd450) at ../../test/monster_test/monster_test.c:1211
#6  0x000000000041e61c in main (argc=1, argv=0x7fffffffd6c8) at ../../test/monster_test/monster_test.c:2860
```