### PR TITLE
Correct FLATCC_INSTALL_LIB bug

### DIFF
--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -39,5 +39,5 @@ endif(FLATCC_REFLECTION)
 add_library(flatcc ${SOURCES})
 
 if (FLATCC_INSTALL)
-    install(TARGETS flatcc DESTINATION lib)
+    install(TARGETS flatcc DESTINATION ${lib_dir})
 endif()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -12,5 +12,5 @@ add_library(flatccrt
 )
 
 if (FLATCC_INSTALL)
-    install(TARGETS flatccrt DESTINATION lib)
+    install(TARGETS flatccrt DESTINATION ${lib_dir})
 endif()


### PR DESCRIPTION
Replace lib with ${lib_dir} in compiler and runtime CMakeLists.