### PR TITLE
Fix mistake when reordering the table field with id attribute

### DIFF
--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -1321,7 +1321,7 @@ static int process_table(fb_parser_t *P, fb_compound_type_t *ct)
             j = 1; /* Adjust for union type. */
         }
         ct->members = field_index[j];
-        for (i = j + 1; i < max_id; ++i) {
+        for (i = j + 1; i <= max_id; ++i) {
             if (field_index[i] == 0) ++i; /* Adjust for union type. */
             field_index[j]->link = field_index[i];
             j = i;


### PR DESCRIPTION
#112 when the table field in the schema has id attribute and not placed in sequence order, flatcc falls into an endless loop because of the mistake when reordering the table field with id attribute