### PR TITLE
Use the correct string ref type in monster sample

### DIFF
--- a/samples/monster/monster.c
+++ b/samples/monster/monster.c
@@ -29,10 +29,10 @@
 // these references.
 int create_monster_bottom_up(flatcc_builder_t *B, int flexible)
 {
-    ns(Weapon_ref_t) weapon_one_name = flatbuffers_string_create_str(B, "Sword");
+    flatbuffers_string_ref_t weapon_one_name = flatbuffers_string_create_str(B, "Sword");
     uint16_t weapon_one_damage = 3;
 
-    ns(Weapon_ref_t) weapon_two_name = flatbuffers_string_create_str(B, "Axe");
+    flatbuffers_string_ref_t weapon_two_name = flatbuffers_string_create_str(B, "Axe");
     uint16_t weapon_two_damage = 5;
 
     // Use the `MyGame_Sample_Weapon_create` shortcut to create Weapons


### PR DESCRIPTION
Some string definitions were typed as ns(Weapon_ref_t) while they should
be flatbuffers_string_ref_t. Note that the former was also compiling &
running correctly as both ref types boil down to the same underlying ref
type.