### PR TITLE
Fix misc build errors on GCC 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,20 @@ elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     else()
         message(STATUS "Setting GNU C compiler options with c11 and Posix")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -pedantic -Wall -Wextra")
+        if (GCC_VERSION VERSION_GREATER_EQUAL 8.0)
+            # Disable some GCC checks:
+            #
+            # -Wstringop-truncation:
+            # strncpy into char arrays in FlatBuffer structs, these are
+            # zero-paddded but not zero terminated
+            #
+            # -Wno-format-overflow:
+            # GCC 9 warns on mistakenly assumed NULL string when 
+            # printing from a required FlatBuffer string field.
+            #
+            message(STATUS "Disabling GNU C compiler warnings: -Wstringop-truncation -Wno-format-overflow")
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-stringop-truncation -Wno-format-overflow")
+        endif()
         if (FLATCC_GNU_POSIX_MEMALIGN)
             # -std=c11 prevents detection of posix_memalign and aligned_alloc might be missing
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPORTABLE_POSIX_MEMALIGN=1")

--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -523,7 +523,7 @@ static int analyze_struct(fb_parser_t *P, fb_compound_type_t *ct)
         member = (fb_member_t *)sym;
         switch (member->type.type) {
         case vt_fixed_array_type:
-            /* -fallthrough */
+            /* fall through */
         case vt_scalar_type:
             t = member->type.t;
             member->type.st = map_scalar_token_type(t);
@@ -536,7 +536,7 @@ static int analyze_struct(fb_parser_t *P, fb_compound_type_t *ct)
             member->size = size * member->type.len;
             break;
         case vt_fixed_array_compound_type_ref:
-            /* -fallthrough */
+            /* fall through */
         case vt_compound_type_ref:
             /* Enums might not be valid, but then it would be detected earlier. */
             if (member->type.ct->symbol.kind == fb_is_enum) {
@@ -700,7 +700,7 @@ static int process_struct(fb_parser_t *P, fb_compound_type_t *ct)
         switch (member->type.type) {
         case vt_fixed_array_type_ref:
             key_ok = 0;
-            /* -fallthrough */
+            /* fall through */
         case vt_type_ref:
             type_sym = lookup_type_reference(P, ct->scope, member->type.ref);
             if (!type_sym) {


### PR DESCRIPTION
Fix the following build errors on Fedora 30:
```
src/compiler/semantics.c:702:20: error: this statement may fall through
  702 |             key_ok = 0;

samples/reflection/bfbs2json.c:86:5: error: ‘%s’ directive argument is null

test/monster_test/monster_test.c:1948:5: error: ‘strncpy’ output truncated copying 5 bytes from a string of length 12
 1948 |     strncpy(foobar->text, "hello, world", ns(FooBar_text_get_len()));
```

I've done zero testing of this other than it builds.