### PR TITLE
Custom assert definition for generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ executable also handle optional json parsing or printing in less than 2 us for a
   * [Docker](#docker)
   * [Cross-compilation](#cross-compilation)
   * [Custom Allocation](#custom-allocation)
+  * [Custom Asserts](#custom-asserts)
   * [Shared Libraries](#shared-libraries)
 * [Distribution](#distribution)
   * [Unix Files](#unix-files)
@@ -2248,6 +2249,30 @@ if doing so. There is a test case implementing a new emitter, and a
 custom allocator can be copied from the one embedded in the builder
 library source.
 
+
+### Custom Asserts
+
+On systems where the default POSIX `assert` call is unavailable, or when 
+a different assert behaviour is desirable, it is possible to override 
+the default behaviour in runtime part of flatcc library via logic defined 
+in [flatcc_assert.h](include/flatcc/flatcc_assert.h).
+
+By default Posix `assert` is beeing used. It can be changed by preprocessor definition:
+
+    -DFLATCC_ASSERT=own_assert
+    
+Please be aware of that, it only changes assert handling in flatcc library. For parsing 
+floating point numbers flatcc uses external Girsu3 library which also uses assertions. 
+To override asserts in Girsu3 library following definition can be used:
+
+    -DGRISU3_ASSERT=own_assert
+
+It is possible to disable assertions by using definitions:
+
+    -DFLATCC_NO_ASSERT
+    -DGRISU3_NO_ASSERT
+
+This will not affect inclusion of <assert.h> for static assertions.
 
 ### Shared Libraries
 

--- a/include/flatcc/flatcc_assert.h
+++ b/include/flatcc/flatcc_assert.h
@@ -1,0 +1,42 @@
+#ifndef FLATCC_ASSERT_H
+#define FLATCC_ASSERT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+* These assert abstraction is __only__ for runtime libraries.
+*
+* The flatcc compiler uses Posix assert routines regardless
+* of how this file is configured.
+*
+* This header makes it possible to use systems where assert is not
+* valid to use.
+*
+* `FLATCC_ASSERT` is designed to handle errors which cannot be ignored
+* and could lead to crash.
+*
+* `FLATCC_ASSERT` can be overrided by preprocessor definition
+*
+* If `FLATCC_ASSERT` definition is not provided, posix assert is being used
+*/
+
+#ifdef FLATCC_NO_ASSERT 
+/* NOTE: This will not affect inclusion of <assert.h> for static assertions. */
+#undef FLATCC_ASSERT
+#define FLATCC_ASSERT(x) ((void)0)
+/* Grisu3 is used for floating point conversion in JSON processing. */
+#define GRISU3_NO_ASSERT
+#endif
+
+#ifndef FLATCC_ASSERT
+#include <assert.h>
+#define FLATCC_ASSERT assert
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLATCC_ASSERT_H */

--- a/include/flatcc/flatcc_builder.h
+++ b/include/flatcc/flatcc_builder.h
@@ -71,7 +71,7 @@ extern "C" {
 
 /* It is possible to enable logging here. */
 #ifndef FLATCC_BUILDER_ASSERT
-#define FLATCC_BUILDER_ASSERT(cond, reason) assert(cond)
+#define FLATCC_BUILDER_ASSERT(cond, reason) FLATCC_ASSERT(cond)
 #endif
 
 /*

--- a/include/flatcc/flatcc_flatbuffers.h
+++ b/include/flatcc/flatcc_flatbuffers.h
@@ -24,6 +24,7 @@ extern "C" {
 #include "flatcc/portable/pstdalign.h"
 
 #include "flatcc/flatcc_alloc.h"
+#include "flatcc/flatcc_assert.h"
 
 #define __FLATBUFFERS_PASTE2(a, b) a ## b
 #define __FLATBUFFERS_PASTE3(a, b, c) a ## b ## c

--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -14,7 +14,6 @@ extern "C" {
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "flatcc/flatcc_rtconfig.h"
 #include "flatcc/flatcc_builder.h"

--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -501,7 +501,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline int N ## _start(NS ## builder_t *B)\\\n"
         "{ return flatcc_builder_start_table(B, K); }\\\n"
         "static inline N ## _ref_t N ## _end(NS ## builder_t *B)\\\n"
-        "{ assert(flatcc_builder_check_required(B, __ ## N ## _required,\\\n"
+        "{ FLATCC_ASSERT(flatcc_builder_check_required(B, __ ## N ## _required,\\\n"
         "  sizeof(__ ## N ## _required) / sizeof(__ ## N ## _required[0]) - 1));\\\n"
         "  return flatcc_builder_end_table(B); }\\\n"
         "__%sbuild_offset_vector(NS, N)\n"

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -263,7 +263,7 @@ static void gen_union(fb_output_t *out)
         "{ return NS ## vec_len(uv__tmp.type); }\\\n"
         "static inline T ## _union_t T ## _union_vec_at(T ## _union_vec_t uv__tmp, size_t i__tmp)\\\n"
         "{ T ## _union_t u__tmp = { 0, 0 }; size_t n__tmp = NS ## vec_len(uv__tmp.type);\\\n"
-        "  assert(n__tmp > (i__tmp) && \"index out of range\"); u__tmp.type = uv__tmp.type[i__tmp];\\\n"
+        "  FLATCC_ASSERT(n__tmp > (i__tmp) && \"index out of range\"); u__tmp.type = uv__tmp.type[i__tmp];\\\n"
         "  /* Unknown type is treated as NONE for schema evolution. */\\\n"
         "  if (u__tmp.type == 0) return u__tmp;\\\n"
         "  u__tmp.value = NS ## generic_vec_at(uv__tmp.value, i__tmp); return u__tmp; }\\\n"
@@ -294,7 +294,7 @@ static void gen_union(fb_output_t *out)
         "static inline T ## _union_vec_t N ## _ ## NK ## _union(N ## _table_t t__tmp)\\\n"
         "{ T ## _union_vec_t uv__tmp; uv__tmp.type = N ## _ ## NK ## _type_get(t__tmp);\\\n"
         "  uv__tmp.value = N ## _ ## NK(t__tmp);\\\n"
-        "  assert(NS ## vec_len(uv__tmp.type) == NS ## vec_len(uv__tmp.value)\\\n"
+        "  FLATCC_ASSERT(NS ## vec_len(uv__tmp.type) == NS ## vec_len(uv__tmp.value)\\\n"
         "  && \"union vector type length mismatch\"); return uv__tmp; }\n",
         nsc);
 }
@@ -502,7 +502,7 @@ static void gen_helpers(fb_output_t *out)
         "#define __%sread_vt(ID, offset, t)\\\n"
         "%svoffset_t offset = 0;\\\n"
         "{   %svoffset_t id__tmp, *vt__tmp;\\\n"
-        "    assert(t != 0 && \"null pointer table access\");\\\n"
+        "    FLATCC_ASSERT(t != 0 && \"null pointer table access\");\\\n"
         "    id__tmp = ID;\\\n"
         "    vt__tmp = (%svoffset_t *)((uint8_t *)(t) -\\\n"
         "        __%ssoffset_read_from_pe(t));\\\n"
@@ -555,7 +555,7 @@ static void gen_helpers(fb_output_t *out)
         "    if (offset__tmp) {\\\n"
         "        return (T)((uint8_t *)(t) + offset__tmp);\\\n"
         "    }\\\n"
-        "    assert(!(r) && \"required field missing\");\\\n"
+        "    FLATCC_ASSERT(!(r) && \"required field missing\");\\\n"
         "    return 0;\\\n"
         "}\n",
         nsc, nsc);
@@ -570,7 +570,7 @@ static void gen_helpers(fb_output_t *out)
         "        return (T)((uint8_t *)(elem__tmp) + adjust +\\\n"
         "              __%suoffset_read_from_pe(elem__tmp));\\\n"
         "    }\\\n"
-        "    assert(!(r) && \"required field missing\");\\\n"
+        "    FLATCC_ASSERT(!(r) && \"required field missing\");\\\n"
         "    return 0;\\\n"
         "}\n",
         nsc, nsc, nsc, nsc, nsc);
@@ -643,18 +643,18 @@ static void gen_helpers(fb_output_t *out)
     fprintf(out->fp,
         /* Tb is the base type for loads. */
         "#define __%sscalar_vec_at(N, vec, i)\\\n"
-        "{ assert(%svec_len(vec) > (i) && \"index out of range\");\\\n"
+        "{ FLATCC_ASSERT(%svec_len(vec) > (i) && \"index out of range\");\\\n"
         "  return __%sread_scalar(N, &(vec)[i]); }\n",
         nsc, nsc, nsc);
     fprintf(out->fp,
         "#define __%sstruct_vec_at(vec, i)\\\n"
-        "{ assert(%svec_len(vec) > (i) && \"index out of range\"); return (vec) + (i); }\n",
+        "{ FLATCC_ASSERT(%svec_len(vec) > (i) && \"index out of range\"); return (vec) + (i); }\n",
         nsc, nsc);
     fprintf(out->fp,
         "/* `adjust` skips past the header for string vectors. */\n"
         "#define __%soffset_vec_at(T, vec, i, adjust)\\\n"
         "{ const %suoffset_t *elem__tmp = (vec) + (i);\\\n"
-        "  assert(%svec_len(vec) > (i) && \"index out of range\");\\\n"
+        "  FLATCC_ASSERT(%svec_len(vec) > (i) && \"index out of range\");\\\n"
         "  return (T)((uint8_t *)(elem__tmp) + (size_t)__%suoffset_read_from_pe(elem__tmp) + (adjust)); }\n",
         nsc, nsc, nsc, nsc);
     fprintf(out->fp,

--- a/src/runtime/builder.c
+++ b/src/runtime/builder.c
@@ -15,7 +15,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "flatcc/flatcc_builder.h"
 #include "flatcc/flatcc_emitter.h"
@@ -338,7 +337,7 @@ static int alloc_ht(flatcc_builder_t *B)
 
     size_t size, k;
     /* Allocate null entry so we can check for return errors. */
-    assert(B->vd_end == 0);
+    FLATCC_ASSERT(B->vd_end == 0);
     if (!reserve_buffer(B, flatcc_builder_alloc_vd, B->vd_end, sizeof(vtable_descriptor_t), 0)) {
         return -1;
     }
@@ -430,7 +429,7 @@ int flatcc_builder_custom_reset(flatcc_builder_t *B, int set_defaults, int reduc
             }
             memset(buf->iov_base, 0, buf->iov_len);
         } else {
-            assert(buf->iov_len == 0);
+            FLATCC_ASSERT(buf->iov_len == 0);
         }
     }
     B->vb_end = 0;
@@ -544,7 +543,7 @@ size_t flatcc_builder_exit_user_frame(flatcc_builder_t *B)
 {
     size_t *hdr;
 
-    assert(B->user_frame_offset > 0);
+    FLATCC_ASSERT(B->user_frame_offset > 0);
 
     hdr = us_ptr(B->user_frame_offset);
     B->user_frame_end = B->user_frame_offset - sizeof(size_t);
@@ -553,7 +552,7 @@ size_t flatcc_builder_exit_user_frame(flatcc_builder_t *B)
 
 size_t flatcc_builder_exit_user_frame_at(flatcc_builder_t *B, size_t handle)
 {
-    assert(B->user_frame_offset >= handle);
+    FLATCC_ASSERT(B->user_frame_offset >= handle);
 
     B->user_frame_offset = handle;
     return flatcc_builder_exit_user_frame(B);
@@ -750,8 +749,8 @@ flatcc_builder_ref_t flatcc_builder_create_buffer(flatcc_builder_t *B,
     }
     set_min_align(B, align);
     if (identifier) {
-        assert(sizeof(flatcc_builder_identifier_t) == identifier_size);
-        assert(sizeof(flatcc_builder_identifier_t) == field_size);
+        FLATCC_ASSERT(sizeof(flatcc_builder_identifier_t) == identifier_size);
+        FLATCC_ASSERT(sizeof(flatcc_builder_identifier_t) == field_size);
         memcpy(&id_out, identifier, identifier_size);
         id_out = __flatbuffers_thash_read_from_le(&id_out);
         write_identifier(&id_out, id_out);
@@ -1741,7 +1740,7 @@ flatcc_builder_ref_t flatcc_builder_end_string(flatcc_builder_t *B)
     flatcc_builder_ref_t string_ref;
 
     check(frame(type) == flatcc_builder_string, "expected string frame");
-    assert(frame(vector.count) == B->ds_offset);
+    FLATCC_ASSERT(frame(vector.count) == B->ds_offset);
     if (0 == (string_ref = flatcc_builder_create_string(B,
             (const char *)B->ds, B->ds_offset))) {
         return 0;

--- a/src/runtime/json_parser.c
+++ b/src/runtime/json_parser.c
@@ -1,5 +1,6 @@
 #include "flatcc/flatcc_rtconfig.h"
 #include "flatcc/flatcc_json_parser.h"
+#include "flatcc/flatcc_assert.h"
 
 #define uoffset_t flatbuffers_uoffset_t
 #define soffset_t flatbuffers_soffset_t
@@ -1080,7 +1081,7 @@ const char *flatcc_json_parser_union_type(flatcc_json_parser_t *ctx,
         f->union_count += e->type != 0;
         return buf;
     }
-    assert(f->union_count);
+    FLATCC_ASSERT(f->union_count);
     --f->union_count;
     /*
      * IMPORTANT: we cannot access any value in the frame or entry
@@ -1237,7 +1238,7 @@ const char *flatcc_json_parser_union_type_vector(flatcc_json_parser_t *ctx,
         ++f->union_count;
         return buf;
     }
-    assert(f->union_count);
+    FLATCC_ASSERT(f->union_count);
     --f->union_count;
     line = ctx->line;
     line_start = ctx->line_start;

--- a/src/runtime/json_printer.c
+++ b/src/runtime/json_printer.c
@@ -3,11 +3,11 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 
 #include "flatcc/flatcc_rtconfig.h"
+#include "flatcc/flatcc_assert.h"
 
 /*
  * Grisu significantly improves printing speed of floating point values
@@ -313,7 +313,7 @@ static void print_uint8_vector_base64_object(flatcc_json_printer_t *ctx, const v
         /* Multiples of 4 output chars consumes exactly 3 bytes before final padding. */
         k = (ctx->pflush - ctx->p) & ~(size_t)3;
         n = k * 3 / 4;
-        assert(n > 0);
+        FLATCC_ASSERT(n > 0);
         src_len = k * 3 / 4;
         base64_encode((uint8_t *)ctx->p, data, 0, &src_len, unpadded_mode);
         ctx->p += k;
@@ -985,7 +985,7 @@ void flatcc_json_printer_union_vector_field(flatcc_json_printer_t *ctx,
     ud.ttl = td->ttl;
     if (len > FLATCC_JSON_PRINT_NAME_LEN_MAX) {
         RAISE_ERROR(bad_input);
-        assert(0 && "identifier too long");
+        FLATCC_ASSERT(0 && "identifier too long");
         return;
     }
     memcpy(type_name, name, len);
@@ -1187,7 +1187,7 @@ static int accept_header(flatcc_json_printer_t * ctx,
 
     if (buf == 0 || bufsiz < offset_size + FLATBUFFERS_IDENTIFIER_SIZE) {
         RAISE_ERROR(bad_input);
-        assert(0 && "buffer header too small");
+        FLATCC_ASSERT(0 && "buffer header too small");
         return 0;
     }
     if (fid != 0) {
@@ -1195,7 +1195,7 @@ static int accept_header(flatcc_json_printer_t * ctx,
         id = __flatbuffers_thash_read_from_pe((uint8_t *)buf + offset_size);
         if (!(id2 == 0 || id == id2)) {
             RAISE_ERROR(bad_input);
-            assert(0 && "identifier mismatch");
+            FLATCC_ASSERT(0 && "identifier mismatch");
             return 0;
         }
     }
@@ -1314,7 +1314,7 @@ int flatcc_json_printer_init(flatcc_json_printer_t *ctx, void *fp)
      * Make sure we have space for primitive operations such as printing numbers
      * without having to flush.
      */
-    assert(ctx->flush_size + FLATCC_JSON_PRINT_RESERVE <= ctx->size);
+    FLATCC_ASSERT(ctx->flush_size + FLATCC_JSON_PRINT_RESERVE <= ctx->size);
     return 0;
 }
 
@@ -1332,7 +1332,7 @@ static void __flatcc_json_printer_flush_buffer(flatcc_json_printer_t *ctx, int a
 
 int flatcc_json_printer_init_buffer(flatcc_json_printer_t *ctx, char *buffer, size_t buffer_size)
 {
-    assert(buffer_size >= FLATCC_JSON_PRINT_RESERVE);
+    FLATCC_ASSERT(buffer_size >= FLATCC_JSON_PRINT_RESERVE);
     if (buffer_size < FLATCC_JSON_PRINT_RESERVE) {
         return -1;
     }

--- a/src/runtime/refmap.c
+++ b/src/runtime/refmap.c
@@ -12,11 +12,11 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "flatcc/flatcc_rtconfig.h"
 #include "flatcc/flatcc_refmap.h"
 #include "flatcc/flatcc_alloc.h"
+#include "flatcc/flatcc_assert.h"
 
 #define _flatcc_refmap_calloc FLATCC_CALLOC
 #define _flatcc_refmap_free FLATCC_FREE
@@ -102,7 +102,7 @@ int flatcc_refmap_resize(flatcc_refmap_t *refmap, size_t count)
         refmap->table = _flatcc_refmap_calloc(buckets, sizeof(refmap->table[0]));
         if (refmap->table == 0) {
             refmap->table = T_old;
-            assert(0); /* out of memory */
+            FLATCC_ASSERT(0); /* out of memory */
             return -1;
         }
     }

--- a/src/runtime/verifier.c
+++ b/src/runtime/verifier.c
@@ -4,7 +4,6 @@
  * Depends mutually on generated verifier functions for table types that
  * call into this library.
  */
-#include <assert.h>
 #include <string.h>
 
 #include "flatcc/flatcc_rtconfig.h"
@@ -18,7 +17,7 @@
 #include <stdio.h>
 #define FLATCC_VERIFIER_ASSERT(cond, reason)                                \
     if (!(cond)) { fprintf(stderr, "verifier assert: %s\n",                 \
-        flatcc_verify_error_string(reason)); assert(0); return reason; }
+        flatcc_verify_error_string(reason)); FLATCC_ASSERT(0); return reason; }
 #endif
 
 #if FLATCC_TRACE_VERIFY
@@ -53,7 +52,7 @@
 
 /* May be redefined for logging purposes. */
 #ifndef FLATCC_VERIFIER_ASSERT
-#define FLATCC_VERIFIER_ASSERT(cond, reason) assert(cond)
+#define FLATCC_VERIFIER_ASSERT(cond, reason) FLATCC_ASSERT(cond)
 #endif
 
 #if FLATCC_VERIFIER_ASSERT_ON_ERROR
@@ -192,8 +191,8 @@ static int verify_field(flatcc_table_verifier_descriptor_t *td,
      * Otherwise range check assumptions break, and normal access code likely also.
      * We don't require voffset_size < uoffset_size, but some checks are faster if true.
      */
-    assert(uoffset_size >= voffset_size);
-    assert(soffset_size == uoffset_size);
+    FLATCC_ASSERT(uoffset_size >= voffset_size);
+    FLATCC_ASSERT(soffset_size == uoffset_size);
 
     vte = read_vt_entry(td, id);
     if (!vte) {


### PR DESCRIPTION
It would be really nice to have a possibility to provide own assert function to generated code. In Google's flatbuffers it is done by providing FLATBUFFERS_ASSERT define. Following change introduces the same mechanism for flatcc.