### PR TITLE
Portability: fix ISO C99 unnamed struct/union

### DIFF
--- a/include/flatcc/flatcc_builder.h
+++ b/include/flatcc/flatcc_builder.h
@@ -353,7 +353,7 @@ struct __flatcc_builder_frame {
         __flatcc_builder_table_frame_t table;
         __flatcc_builder_vector_frame_t vector;
         __flatcc_builder_buffer_frame_t buffer;
-    };
+    } container;
 };
 
 /**


### PR DESCRIPTION
There is one unnamed union inside _**struct __flatcc_builder_frame**_ that, even when compiled with gcc _**-std=c99**_ flag, is only caught with the _**-pedantic-errors**_ flag.

This change-request simply names the union and updates instances where the _**frame()**_ macro accesses the union