### PR TITLE
fix a "-Wstrict-prototypes" warning

### DIFF
--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -1923,7 +1923,7 @@ static int gen_union(fb_output_t *out, fb_compound_type_t *ct)
             break;
         case vt_missing:
             fprintf(out->fp,
-                "static inline %s_union_ref_t %s_as_NONE()\n"
+                "static inline %s_union_ref_t %s_as_NONE(void)\n"
                 "{ %s_union_ref_t uref; uref.type = %s_NONE; uref.value = 0; return uref; }\n",
                 snt.text, snt.text, snt.text, snt.text);
             break;


### PR DESCRIPTION
I looked at adding -Wstrict-prototypes for the build, but it's already enabled in clang, which is the default compiler on my current system (and I don't have enough familiarity with CMake to quickly set up a build with a non-default compiler).  In a different project with a different build system, this particular change cleans the strict-prototypes warning for GCC, though.