### PR TITLE
Fix standalone -c and --common_builder options

### DIFF
--- a/src/cli/flatcc_cli.c
+++ b/src/cli/flatcc_cli.c
@@ -427,10 +427,12 @@ int main(int argc, const char *argv[])
     }
  
     parse_opts(argc, argv, &opts);
-    opts.cgen_common_builder = opts.cgen_builder && opts.cgen_common_reader;
+    if (opts.cgen_builder && opts.cgen_common_reader) {
+        opts.cgen_common_builder = 1;
+    }
     if (opts.srcpath_count == 0) {
-        /* No input files, so only generate header. */
-        if (!opts.cgen_common_reader || opts.bgen_bfbs) {
+        /* No input files, so only generate header(s). */
+        if (!(opts.cgen_common_reader || opts.cgen_common_builder) || opts.bgen_bfbs) {
             fprintf(stderr, "filename missing\n");
             goto fail;
         }


### PR DESCRIPTION
"flatcc -c" without any source file doesn't produce the flatbuffers_common_builder.h header at the moment (line 430 cleared the cgen_common_builder option). Furthermore "flatcc --common_builder" mistakenly requires a source file (line 433), while it shouldn't need one. Both issues are addressed in this commit.