### PR TITLE
Add RPC data to bfbs binary schema format

### DIFF
--- a/samples/reflection/bfbs2json.c
+++ b/samples/reflection/bfbs2json.c
@@ -174,10 +174,50 @@ void print_enum(reflection_Enum_table_t E)
     printf("}");
 }
 
+void print_call(reflection_RPCCall_table_t C)
+{
+    printf("{\"name\":\"%s\"", reflection_RPCCall_name(C));
+    printf(",\"request\":");
+    print_object(reflection_RPCCall_request(C));
+    printf(",\"response\":");
+    print_object(reflection_RPCCall_response(C));
+
+    if (reflection_RPCCall_attributes_is_present(C)) {
+        printf(",\"attributes\":");
+        print_attributes(reflection_RPCCall_attributes(C));
+    }
+    printf("}");
+}
+
+void print_service(reflection_Service_table_t S)
+{
+    reflection_RPCCall_vec_t calls;
+    size_t i;
+
+    printf("{\"name\":\"%s\"", reflection_Service_name(S));
+
+    printf(",\"calls\":[");
+    calls = reflection_Service_calls(S);
+    for (i = 0; i < reflection_RPCCall_vec_len(calls); ++i) {
+        if (i > 0) {
+            printf(",");
+        }
+        print_call(reflection_RPCCall_vec_at(calls, i));
+    }
+    printf("]");
+
+    if (reflection_Service_attributes_is_present(S)) {
+        printf(",\"attributes\":");
+        print_attributes(reflection_Service_attributes(S));
+    }
+    printf("}");
+}
+
 void print_schema(reflection_Schema_table_t S)
 {
     reflection_Object_vec_t Objs;
     reflection_Enum_vec_t Enums;
+    reflection_Service_vec_t Services;
     size_t i;
 
     Objs = reflection_Schema_objects(S);
@@ -208,6 +248,17 @@ void print_schema(reflection_Schema_table_t S)
     if (reflection_Schema_root_table_is_present(S)) {
         printf(",\"root_table\":");
         print_object(reflection_Schema_root_table(S));
+    }
+    if (reflection_Schema_services_is_present(S)) {
+        printf(",\"services\":[");
+        Services = reflection_Schema_services(S);
+        for (i = 0; i < reflection_Service_vec_len(Services); ++i) {
+            if (i > 0) {
+                printf(",");
+            }
+            print_service(reflection_Service_vec_at(Services, i));
+        }
+        printf("]");
     }
     printf("}\n");
 }

--- a/src/compiler/codegen_schema.c
+++ b/src/compiler/codegen_schema.c
@@ -345,6 +345,47 @@ static void export_root_type(flatcc_builder_t *B, fb_symbol_t * root_type,
     }
 }
 
+static void export_call(flatcc_builder_t *B, fb_member_t *member, reflection_Object_ref_t *object_map)
+{
+    reflection_RPCCall_vec_push_start(B);
+    reflection_RPCCall_name_create(B, member->symbol.ident->text, (size_t)member->symbol.ident->len);
+    reflection_RPCCall_request_add(B, object_map[member->req_type.ct->export_index]);
+    reflection_RPCCall_response_add(B, object_map[member->type.ct->export_index]);
+    if (member->metadata) {
+        reflection_RPCCall_attributes_start(B);
+        export_attributes(B, member->metadata);
+        reflection_RPCCall_attributes_end(B);
+    }
+    reflection_RPCCall_vec_push_end(B);
+}
+
+static void export_services(flatcc_builder_t *B, service_entry_t *services, int nservices,
+        reflection_Object_ref_t *object_map)
+{
+    int i;
+    fb_compound_type_t *ct;
+    fb_symbol_t *sym;
+
+    reflection_Schema_services_start(B);
+    for (i = 0; i < nservices; ++i) {
+        ct = services[i].ct;
+        reflection_Service_vec_push_start(B);
+        reflection_Service_name_create_str(B, services[i].name);
+        reflection_Service_calls_start(B);
+        for (sym = ct->members; sym; sym = sym->link) {
+            export_call(B, (fb_member_t *)sym, object_map);
+        }
+        reflection_Service_calls_end(B);
+        if (ct->metadata) {
+            reflection_Service_attributes_start(B);
+            export_attributes(B, ct->metadata);
+            reflection_Service_attributes_end(B);
+        }
+        reflection_Service_vec_push_end(B);
+    }
+    reflection_Schema_services_end(B);
+}
+
 static int export_schema(flatcc_builder_t *B, fb_options_t *opts, fb_schema_t *S)
 {
     catalog_t catalog;
@@ -377,6 +418,7 @@ static int export_schema(flatcc_builder_t *B, fb_options_t *opts, fb_schema_t *S
     export_objects(B, catalog.objects, catalog.nobjects, object_map);
     export_enums(B, catalog.enums, catalog.nenums, object_map);
     export_root_type(B, S->root_type.type, object_map);
+    export_services(B, catalog.services, catalog.nservices, object_map);
 
     reflection_Schema_end_as_root(B);
 


### PR DESCRIPTION
The sample bfbs2json was ignoring services present in BFBS
files generated by flatc. After this change, it outputs
the JSON output:

 "service": [
   { "name": "<service-name>",
     "calls": [
        { "name": "<RPCCall-name>",
          "request": <request-object>,
          "response": <response-object> }
        ...
     ]
   }
   ...
 ]

(optional attributes not shown)