### PR TITLE
Fix per-table file identifiers and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,8 +1280,8 @@ and so does other `_as_root` methods.
 
 The `file_extension` is handled in a similar manner:
 
-    #ifndef MyGame_Example_Monster_extension
-    #define MyGame_Example_Monster_extension flatbuffers_extension
+    #ifndef MyGame_Example_Monster_file_extension
+    #define MyGame_Example_Monster_file_extension "mon"
     #endif
 
 ### Type Identifiers

--- a/README.md
+++ b/README.md
@@ -1263,16 +1263,13 @@ defined as the null identifier.
 
 The generated code defines the identifiers for a given table:
 
-    #ifndef MyGame_Example_Monster_identifier
-    #define MyGame_Example_Monster_identifier flatbuffers_identifier
+    #ifndef MyGame_Example_Monster_file_identifier
+    #define MyGame_Example_Monster_file_identifier "MONS"
     #endif
-
-The `flatbuffers_identifier` is the schema specific `file_identifier`
-and is undefined and redefined for each generated `_reader.h` file.
 
 The user can now override the identifier for a given type, for example:
 
-    #define MyGame_Example_Vec3_identifier "VEC3"
+    #define MyGame_Example_Vec3_file_identifier "VEC3"
     #include "monster_test_builder.h"
 
     ...

--- a/config/config.h
+++ b/config/config.h
@@ -337,8 +337,9 @@
 #define FLATCC_DEFAULT_BIN_SCHEMA_EXT ".bfbs"
 #endif
 
+/* Schema file extensions do not carry a dot by convention, do the same here. */
 #ifndef FLATCC_DEFAULT_BIN_EXT
-#define FLATCC_DEFAULT_BIN_EXT ".bin"
+#define FLATCC_DEFAULT_BIN_EXT "bin"
 #endif
 
 #ifndef FLATCC_DEFAULT_DEP_EXT

--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -897,12 +897,11 @@ static int gen_builder_pretext(fb_output_t *out)
     if (out->S->file_extension.type == vt_string) {
         fprintf(out->fp,
             "#undef %sextension\n"
-            "#define %sextension \".%.*s\"\n",
+            "#define %sextension \"%.*s\"\n",
             nsc,
             nsc, out->S->file_extension.s.len, out->S->file_extension.s.s);
     } else {
         fprintf(out->fp,
-            /* Configured extensions include dot, schema does not. */
             "#ifndef %sextension\n"
             "#define %sextension \"%s\"\n"
             "#endif\n",

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -104,6 +104,30 @@ static void print_type_identifier(fb_output_t *out, fb_compound_type_t *ct)
         name, buf);
 }
 
+static void print_file_extension(fb_output_t *out, fb_compound_type_t *ct)
+{
+    fb_scoped_name_t snt;
+    const char *name;
+
+    fb_clear(snt);
+    fb_compound_name(ct, &snt);
+    name = snt.text;
+
+    if (out->S->file_extension.type == vt_string) {
+        fprintf(out->fp,
+                "#ifndef %s_file_extension\n"
+                "#define %s_file_extension \"%.*s\"\n"
+                "#endif\n",
+                name, name, out->S->file_extension.s.len, out->S->file_extension.s.s);
+    } else {
+        fprintf(out->fp,
+                "#ifndef %s_file_extension\n"
+                "#define %s_file_extension \"%s\"\n"
+                "#endif\n",
+                name, name, out->opts->default_bin_ext);
+    }
+}
+
 /* Finds first occurrence of matching key when vector is sorted on the named field. */
 static void gen_find(fb_output_t *out)
 {
@@ -1859,6 +1883,7 @@ int fb_gen_c_reader(fb_output_t *out)
             /* Fall through. */
         case fb_is_table:
             print_type_identifier(out, (fb_compound_type_t *)sym);
+            print_file_extension(out, (fb_compound_type_t *)sym);
             break;
         }
     }

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -1021,12 +1021,11 @@ static void gen_pretext(fb_output_t *out)
     if (out->S->file_extension.type == vt_string) {
         fprintf(out->fp,
             "#undef %sextension\n"
-            "#define %sextension \".%.*s\"\n",
+            "#define %sextension \"%.*s\"\n",
             nsc,
             nsc, out->S->file_extension.s.len, out->S->file_extension.s.s);
     } else {
         fprintf(out->fp,
-            /* Configured extensions include dot, schema does not. */
             "#ifndef %sextension\n"
             "#define %sextension \"%s\"\n"
             "#endif\n",

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -37,6 +37,9 @@ static void print_type_identifier(fb_output_t *out, fb_compound_type_t *ct)
     uint32_t type_hash;
     int conflict = 0;
     fb_symbol_t *sym;
+    const char *file_identifier;
+    int file_identifier_len;
+    const char *quote;
 
     fb_clear(snt);
 
@@ -54,19 +57,28 @@ static void print_type_identifier(fb_output_t *out, fb_compound_type_t *ct)
             break;
         }
     }
+    if (out->S->file_identifier.type == vt_string) {
+        quote = "\"";
+        file_identifier = out->S->file_identifier.s.s;
+        file_identifier_len = out->S->file_identifier.s.len;
+    } else {
+        quote = "";
+        file_identifier = "0";
+        file_identifier_len = 1;
+    }
     fprintf(out->fp,
             "#ifndef %s_file_identifier\n"
-            "#define %s_file_identifier %sidentifier\n"
+            "#define %s_file_identifier %s%.*s%s\n"
             "#endif\n",
-            name, name, nsc);
+            name, name, quote, file_identifier_len, file_identifier, quote);
     if (!conflict) {
         /* For backwards compatibility. */
         fprintf(out->fp,
                 "/* deprecated, use %s_file_identifier */\n"
                 "#ifndef %s_identifier\n"
-                "#define %s_identifier %sidentifier\n"
+                "#define %s_identifier %s%.*s%s\n"
                 "#endif\n",
-                name, name, name, nsc);
+                name, name, name, quote, file_identifier_len, file_identifier, quote);
     }
     fprintf(out->fp,
         "#define %s_type_hash ((%sthash_t)0x%lx)\n",


### PR DESCRIPTION
(Extracted from PR #185)

These 2 commits change how per-table file identifiers and extensions are generated:
- the file identifiers should not use `flatbuffers_identifier` because it prevents from including several schema definitions, use a direct string instead
- the per-table file extensions are not generated, let's add them similarly to file identifiers

changes in v2:
- fix documentation (README.md)
