### PR TITLE
fix flatcc return code on include failure

### DIFF
--- a/src/compiler/flatcc.c
+++ b/src/compiler/flatcc.c
@@ -345,7 +345,6 @@ int flatcc_parse_file(flatcc_context_t ctx, const char *filename)
         if (!(buf = fb_read_file(filename, P->opts.max_schema_size, &size))) {
             if (size + P->schema.root_schema->total_source_size > P->opts.max_schema_size && P->opts.max_schema_size > 0) {
                 fb_print_error(P, "input exceeds maximum allowed size\n");
-                ret = -1;
                 goto done;
             }
         } else {
@@ -361,7 +360,6 @@ int flatcc_parse_file(flatcc_context_t ctx, const char *filename)
             path = 0;
             if (size > P->opts.max_schema_size && P->opts.max_schema_size > 0) {
                 fb_print_error(P, "input exceeds maximum allowed size\n");
-                ret = -1;
                 goto done;
             }
         }
@@ -375,7 +373,6 @@ int flatcc_parse_file(flatcc_context_t ctx, const char *filename)
             path = 0;
             if (size > P->opts.max_schema_size && P->opts.max_schema_size > 0) {
                 fb_print_error(P, "input exceeds maximum allowed size\n");
-                ret = -1;
                 goto done;
             }
         }
@@ -393,7 +390,7 @@ int flatcc_parse_file(flatcc_context_t ctx, const char *filename)
      * need to parse all include files to make sense of the current
      * file.
      */
-    if (!(ret = fb_parse(P, buf, size, 1))) {
+    if (!fb_parse(P, buf, size, 1)) {
         /* Parser owns buffer. */
         buf = 0;
         inc = P->schema.includes;


### PR DESCRIPTION
When the file being compiled includes another one that does not exist,
the generation fails but the return code is 0:

  user@host:$ echo 'include "unexistant_file.fbs";' > schema.fbs
  user@host:$ flatcc schema.fbs
  error reading included schema file: attributes.fbs
  user@host:$ echo $?
  0

In flatcc_parse_file(), the ret variable is initialized to -1 at the
beginning of the function, but modified to 0 when fb_parse() is called
with success. Subsequent "goto done" do not set back ret to -1, so the
return value is 0 when the file is not found.

Let's remove the use of ret in the fb_parse() test, and remove the
uneeded affectations of ret above.

Signed-off-by: Olivier Matz <olivier.matz@6wind.com>