### PR TITLE
fix potential memory leaks in fileio.c and semantics.c

### DIFF
--- a/src/compiler/fileio.c
+++ b/src/compiler/fileio.c
@@ -62,8 +62,10 @@ char *fb_create_join_path_n(const char *prefix, size_t prefix_len,
         return 0;
     }
     n = 0;
-    memcpy(path, prefix, prefix_len);
-    n += prefix_len;
+    if (prefix_len > 0) {
+        memcpy(path, prefix, prefix_len);
+        n += prefix_len;
+    }
     if (path_sep) {
         path[n++] = '/';
     }

--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -1543,7 +1543,7 @@ static int process_enum(fb_parser_t *P, fb_compound_type_t *ct)
     fb_symbol_t *sym, *old, *type_sym;
     fb_member_t *member;
     fb_metadata_t *knowns[KNOWN_ATTR_COUNT];
-    fb_value_t index;
+    fb_value_t index = { 0 };
     fb_value_t old_index;
     int first = 1;
     int bit_flags = 0;


### PR DESCRIPTION
This fixes potential memory leaks that were detected by a quick run of cppcheck. In `fileio.c`, `memcpy()` will only copy from `prefix` to `path` if `prefix_len` is greater than 0, so copying from a potentially null pointer is avoided. In `semantics.c`, `index.len` is set accordingly based on `index.type` so that the former variable will always be initialized.