### PR TITLE
Remove strict prototypes from clang build

### DIFF
--- a/test/emit_test/emit_test.c
+++ b/test/emit_test/emit_test.c
@@ -30,7 +30,7 @@ int dbg_emitter(void *emit_context,
     return 0;
 }
 
-int debug_test()
+int debug_test(void)
 {
     flatcc_builder_t builder, *B;
     float x[10] = { 0 };
@@ -48,7 +48,7 @@ int debug_test()
  * this assumes a very simple schema:
  * "table { time: long; device: ubyte; samples: [float]; }"
  */
-int emit_test()
+int emit_test(void)
 {
     /*
      * Note that there is some apparently unnecessary padding after 0x01

--- a/test/json_test/test_json.c
+++ b/test/json_test/test_json.c
@@ -139,7 +139,7 @@ failed:
 #define TEST_ERROR_FLAGS(fparse, fprint, x, err) \
     ret |= test_json(scope, (x), 0, err, (fparse), (fprint), __LINE__);
 
-int edge_case_tests()
+int edge_case_tests(void)
 {
     BEGIN_TEST(Monster);
 /*
@@ -280,7 +280,7 @@ int edge_case_tests()
     END_TEST();
 }
 
-int error_case_tests()
+int error_case_tests(void)
 {
     BEGIN_TEST(Monster);
 
@@ -363,7 +363,7 @@ int error_case_tests()
 #define RANDOM_BASE64URL_NOPAD "zLOuiUjH49tz4Ap2JnmpTX5NqoiMzlD8hSw45QCS2yaSp7UYoA" \
     "oE8KpY_5pKYmk-54NI40hyeyZ1zRUE4vKQT0hEdVl0iXq2fqPamkVD1AZlVvQJ1m00PaoXOSgG-64Zv-Uygw"
 
-int base64_tests()
+int base64_tests(void)
 {
     BEGIN_TEST(Monster);
 
@@ -425,7 +425,7 @@ int base64_tests()
     END_TEST();
 }
 
-int mixed_type_union_tests()
+int mixed_type_union_tests(void)
 {
     BEGIN_TEST(Movie);
 
@@ -479,7 +479,7 @@ int mixed_type_union_tests()
     END_TEST();
 }
 
-int union_vector_tests()
+int union_vector_tests(void)
 {
     BEGIN_TEST(Alt);
     /* Union vector */
@@ -505,7 +505,7 @@ int union_vector_tests()
     END_TEST();
 }
 
-int fixed_array_tests()
+int fixed_array_tests(void)
 {
     BEGIN_TEST(Alt);
     /* Fixed array */

--- a/test/json_test/test_json_parser.c
+++ b/test/json_test/test_json_parser.c
@@ -64,7 +64,7 @@ int verify_parse(void *buffer)
 // first iteration. This suggests there is an end check missing somwhere
 // and this needs to be debugged. The input size as of this writing is 701
 // bytes, and the output size is 288 bytes.
-int test_parse()
+int test_parse(void)
 {
 #if FLATCC_BENCHMARK
     double t1, t2;

--- a/test/json_test/test_json_printer.c
+++ b/test/json_test/test_json_printer.c
@@ -23,7 +23,7 @@ const char *filename = 0; /* "monsterdata_test.mon"; */
 const char *golden_filename = "monsterdata_test.golden";
 const char *target_filename = "monsterdata_test.json.txt";
 
-int test_print()
+int test_print(void)
 {
     int ret = 0;
     const char *buf = 0;

--- a/test/optional_scalars_test/optional_scalars_test.c
+++ b/test/optional_scalars_test/optional_scalars_test.c
@@ -159,7 +159,7 @@ int access_scalar_stuff(const void *buf)
     return 0;
 }
 
-int test()
+int test(void)
 {
     flatcc_builder_t builder;
     void  *buf;
@@ -192,7 +192,7 @@ int print_buffer(const void *buf, size_t size)
 }
 #endif
 
-int test_json_printer()
+int test_json_printer(void)
 {
     flatcc_builder_t builder;
     void  *buf;
@@ -219,7 +219,7 @@ int test_json_printer()
     return 0;
 }
 
-int test_json_parser()
+int test_json_parser(void)
 {
     flatcc_builder_t builder;
     void  *buf;


### PR DESCRIPTION
 The build was failing on test functions missing prototypes.

Sample: 
```
FAILED: test/json_test/CMakeFiles/json_test_uq.dir/test_json.c.o
/Library/Developer/CommandLineTools/usr/bin/cc  -Itest/json_test/generated -I../../include -DFLATCC_REFLECTION=1 -Wstrict-prototypes -Wsign-conversion -Wconversion -std=c11 -pedantic -Wall -Wextra -Werror -g -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk -DFLATCC_JSON_PARSE_ALLOW_UNQUOTED=1 -MD -MT test/json_test/CMakeFiles/json_test_uq.dir/test_json.c.o -MF test/json_test/CMakeFiles/json_test_uq.dir/test_json.c.o.d -o test/json_test/CMakeFiles/json_test_uq.dir/test_json.c.o -c ../../test/json_test/test_json.c
../../test/json_test/test_json.c:142:20: error: this old-style function definition is not preceded by a prototype [-Werror,-Wstrict-prototypes]
int edge_case_tests()
```