### PR TITLE
Annotate fallthrough paths with attribute

### DIFF
--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -246,21 +246,21 @@ static inline uint64_t flatcc_json_parser_symbol_part_ext(const char *buf, const
     /* Fall through comments needed to silence gcc 7 warnings. */
     switch (n) {
     case 8: w |= ((uint64_t)buf[7]) << (0 * 8);
-        /* Fall through */
+        fallthrough;
     case 7: w |= ((uint64_t)buf[6]) << (1 * 8);
-        /* Fall through */
+        fallthrough;
     case 6: w |= ((uint64_t)buf[5]) << (2 * 8);
-        /* Fall through */
+        fallthrough;
     case 5: w |= ((uint64_t)buf[4]) << (3 * 8);
-        /* Fall through */
+        fallthrough;
     case 4: w |= ((uint64_t)buf[3]) << (4 * 8);
-        /* Fall through */
+        fallthrough;
     case 3: w |= ((uint64_t)buf[2]) << (5 * 8);
-        /* Fall through */
+        fallthrough;
     case 2: w |= ((uint64_t)buf[1]) << (6 * 8);
-        /* Fall through */
+        fallthrough;
     case 1: w |= ((uint64_t)buf[0]) << (7 * 8);
-        /* Fall through */
+        fallthrough;
     case 0:
         break;
     }

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -8,6 +8,8 @@
 #include <inttypes.h>
 #endif
 
+#include "flatcc/portable/pattributes.h" /* fallthrough */
+
 #define PRINTLN_SPMAX 64
 static char println_spaces[PRINTLN_SPMAX];
 
@@ -1768,6 +1770,7 @@ static int gen_json_parser_prototypes(fb_output_t *out)
     println(out, "const char *buf, size_t bufsiz, int flags);");
     unindent(); unindent();
         println(out, "");
+        fallthrough;
     default:
         break;
     }

--- a/src/compiler/codegen_c_json_printer.c
+++ b/src/compiler/codegen_c_json_printer.c
@@ -6,6 +6,8 @@
 #include <inttypes.h>
 #endif
 
+#include "flatcc/portable/pattributes.h" /* fallthrough */
+
 static int gen_json_printer_pretext(fb_output_t *out)
 {
     fprintf(out->fp,
@@ -581,6 +583,7 @@ static int gen_json_printer_prototypes(fb_output_t *out)
     fprintf(out->fp,
             "static int %s_print_json(flatcc_json_printer_t *ctx, const char *buf, size_t bufsiz);\n\n",
             out->S->basename);
+        fallthrough;
     default:
         break;
     }

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -16,6 +16,7 @@
 #include "codegen.h"
 #include "fileio.h"
 #include "pstrutil.h"
+#include "flatcc/portable/pattributes.h" /* fallthrough */
 #include "flatcc/portable/pparseint.h"
 
 void fb_default_error_out(void *err_ctx, const char *buf, size_t len)
@@ -919,6 +920,7 @@ static void parse_enum_decl(fb_parser_t *P, fb_compound_type_t *ct)
             case tok_kw_float32:
             case tok_kw_float64:
                 error_tok(P, ct->type.t, "integral type expected");
+                fallthrough;
             default:
                 break;
             }

--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -11,6 +11,8 @@
 #include <inttypes.h>
 #endif
 
+#include "flatcc/portable/pattributes.h" /* fallthrough */
+
 /* Same order as enum! */
 static const char *fb_known_attribute_names[] = {
     "",
@@ -699,7 +701,7 @@ static int process_struct(fb_parser_t *P, fb_compound_type_t *ct)
         switch (member->type.type) {
         case vt_fixed_array_type_ref:
             key_ok = 0;
-            /* fall through */
+            fallthrough;
         case vt_type_ref:
             type_sym = lookup_type_reference(P, ct->scope, member->type.ref);
             if (!type_sym) {

--- a/src/runtime/json_parser.c
+++ b/src/runtime/json_parser.c
@@ -144,8 +144,8 @@ descend:
         /* Fall through comments needed to silence gcc 7 warnings. */
         switch (*buf) {
         case 0x0d: buf += (end - buf > 1 && buf[1] == 0x0a);
-            /* Fall through */
             /* Consume following LF or treating CR as LF. */
+            fallthrough;
         case 0x0a: ++ctx->line; ctx->line_start = ++buf; continue;
         case 0x09: ++buf; continue;
         case 0x20: goto again; /* Don't consume here, sync with power of 2 spaces. */


### PR DESCRIPTION
This uses the GNU extension of `__attribute__((__fallthrough__))` to
indicate the fallthrough paths.  The comments were introduced in GCC 7,
which introduced this attribute.  Adding this attribute additionally
silences the warning from clang.