### PR TITLE
build: repair the build where CMake is not on the path

### DIFF
--- a/samples/monster/CMakeLists.txt
+++ b/samples/monster/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_fbs ALL) 
 add_custom_command (
     TARGET gen_monster_fbs
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/monster.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster.fbs" 
 )

--- a/samples/reflection/CMakeLists.txt
+++ b/samples/reflection/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_bfbs ALL)
 add_custom_command (
     TARGET gen_monster_bfbs
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli --schema -o "${GEN_DIR}" "${FBS_DIR}/monster.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster.fbs"
 )

--- a/test/emit_test/CMakeLists.txt
+++ b/test/emit_test/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_emit_test ALL) 
 add_custom_command (
     TARGET gen_emit_test
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/emit_test.fbs"
     DEPENDS flatcc_cli "${FBS}"
 )

--- a/test/flatc_compat/CMakeLists.txt
+++ b/test/flatc_compat/CMakeLists.txt
@@ -9,8 +9,8 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_flatc_compat ALL) 
 add_custom_command (
     TARGET gen_flatc_compat
-    COMMAND cmake -E make_directory "${GEN_DIR}"
-    COMMAND cmake -E copy "${CMAKE_CURRENT_SOURCE_DIR}/monsterdata_test.mon" ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/monsterdata_test.mon" ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/monster_test.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )

--- a/test/json_test/CMakeLists.txt
+++ b/test/json_test/CMakeLists.txt
@@ -12,9 +12,9 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_test_json ALL)
 add_custom_command (
     TARGET gen_monster_test_json
-    COMMAND cmake -E make_directory "${GEN_DIR}"
-    COMMAND cmake -E copy "${DATA_SRC}/monsterdata_test.golden" "${DATA_DST}"
-    COMMAND cmake -E copy "${DATA_SRC}/monsterdata_test.mon" "${DATA_DST}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${DATA_SRC}/monsterdata_test.golden" "${DATA_DST}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${DATA_SRC}/monsterdata_test.mon" "${DATA_DST}"
     COMMAND flatcc_cli -av --json -o "${GEN_DIR}" "${FBS_DIR}/monster_test.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )

--- a/test/load_test/CMakeLists.txt
+++ b/test/load_test/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_load_test ALL) 
 add_custom_command (
     TARGET gen_load_test
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/monster_test.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )

--- a/test/monster_test/CMakeLists.txt
+++ b/test/monster_test/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_test ALL) 
 add_custom_command (
     TARGET gen_monster_test
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/monster_test.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )

--- a/test/monster_test_concat/CMakeLists.txt
+++ b/test/monster_test_concat/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_test_concat ALL) 
 add_custom_command (
     TARGET gen_monster_test_concat
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     # We could also use the recursive -r option, but this tests adding files manually to the output file.
     COMMAND flatcc_cli -cwv --reader -o "${GEN_DIR}" "--outfile=monster_test.h" "${FBS_DIR}/attributes.fbs" "${FBS_DIR}/include_test2.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/monster_test.fbs" DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs" "${FBS_DIR}/attributes.fbs" 
 )

--- a/test/monster_test_cpp/CMakeLists.txt
+++ b/test/monster_test_cpp/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_test_cpp ALL)
 add_custom_command (
     TARGET gen_monster_test_cpp
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/monster.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster.fbs"
 )

--- a/test/monster_test_prefix/CMakeLists.txt
+++ b/test/monster_test_prefix/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_test_prefix ALL) 
 add_custom_command (
     TARGET gen_monster_test_prefix
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a --prefix=zzz_ --stdout "${FBS_DIR}/monster_test.fbs" > "${GEN_DIR}/zzz_monster_test.h"
     DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )

--- a/test/monster_test_solo/CMakeLists.txt
+++ b/test/monster_test_solo/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_monster_test_solo ALL) 
 add_custom_command (
     TARGET gen_monster_test_solo
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -cwv --reader --stdout "${FBS_DIR}/attributes.fbs" "${FBS_DIR}/include_test2.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/monster_test.fbs" > "${GEN_DIR}/monster_test.h" DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs" "${FBS_DIR}/attributes.fbs"
 )
 

--- a/test/optional_scalars_test/CMakeLists.txt
+++ b/test/optional_scalars_test/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_optional_scalars_test ALL) 
 add_custom_command (
     TARGET gen_optional_scalars_test
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli -a --json -o "${GEN_DIR}" "${FBS_DIR}/optional_scalars_test.fbs"
 )
 add_executable(optional_scalars_test optional_scalars_test.c)

--- a/test/reflection_test/CMakeLists.txt
+++ b/test/reflection_test/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories("${GEN_DIR}" "${INC_DIR}")
 add_custom_target(gen_reflection_test ALL) 
 add_custom_command (
     TARGET gen_reflection_test
-    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
     COMMAND flatcc_cli --schema -o "${GEN_DIR}" "${FBS_DIR}/monster_test.fbs"
     DEPENDS flatcc_cli "${FBS_DIR}/monster_test.fbs" "${FBS_DIR}/include_test1.fbs" "${FBS_DIR}/include_test2.fbs"
 )


### PR DESCRIPTION
When cmake is not on the path, the build would previously fail as it
hardcoded the name for the cmake binary, expecting to find it on the
path.  Use `CMAKE_COMMAND` instead to reference the cmake binary that
was used to configure the target.