### PR TITLE
Minimal reproduction test case for misaligned vector of double

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(json_test)
 add_subdirectory(emit_test)
 add_subdirectory(load_test)
 add_subdirectory(optional_scalars_test)
+add_subdirectory(doublevec_test)
 # Reflection can break during development, so it is necessary
 # to disable until new reflection code generates cleanly.
 if (FLATCC_REFLECTION)

--- a/test/doublevec_test/CMakeLists.txt
+++ b/test/doublevec_test/CMakeLists.txt
@@ -1,0 +1,20 @@
+include(CTest)
+
+set(INC_DIR "${PROJECT_SOURCE_DIR}/include")
+set(GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(FBS_DIR "${PROJECT_SOURCE_DIR}/test/doublevec_test")
+
+include_directories("${GEN_DIR}" "${INC_DIR}")
+
+add_custom_target(gen_doublevec_test ALL) 
+add_custom_command (
+    TARGET gen_doublevec_test
+    COMMAND cmake -E make_directory "${GEN_DIR}"
+    COMMAND flatcc_cli -a -o "${GEN_DIR}" "${FBS_DIR}/doublevec_test.fbs"
+    DEPENDS flatcc_cli "${FBS_DIR}/header.fbs"
+)
+add_executable(doublevec_test doublevec_test.c)
+add_dependencies(doublevec_test gen_doublevec_test)
+target_link_libraries(doublevec_test flatccrt)
+
+add_test(doublevec_test doublevec_test${CMAKE_EXECUTABLE_SUFFIX})

--- a/test/doublevec_test/doublevec_test.c
+++ b/test/doublevec_test/doublevec_test.c
@@ -1,0 +1,113 @@
+#include <stdio.h>
+
+#include "doublevec_test_builder.h"
+#include "doublevec_test_verifier.h"
+
+#include "flatcc/support/hexdump.h"
+#include "flatcc/support/elapsed.h"
+#include "../../config/config.h"
+
+#undef nsc
+#define nsc(x) FLATBUFFERS_WRAP_NAMESPACE(flatbuffers, x)
+
+int gen_doublevec(flatcc_builder_t *B)
+{
+    flatcc_builder_reset(B);
+
+    DoubleVec_start_as_root(B);
+    DoubleVec_a_create(B, 0, 0);
+    DoubleVec_end_as_root(B);
+
+    return 0;
+}
+
+int gen_doublevec_with_size(flatcc_builder_t *B)
+{
+    flatcc_builder_reset(B);
+
+    DoubleVec_start_as_root_with_size(B);
+    DoubleVec_a_create(B, 0, 0);
+    DoubleVec_end_as_root(B);
+
+    return 0;
+}
+
+int test_doublevec(flatcc_builder_t *B)
+{
+    void *buffer;
+    size_t size;
+    int ret;
+
+    gen_doublevec(B);
+
+    buffer = flatcc_builder_finalize_aligned_buffer(B, &size);
+    hexdump("doublevec table", buffer, size, stderr);
+
+    if ((ret = DoubleVec_verify_as_root(buffer, size))) {
+        printf("doublevec buffer failed to verify, got: %s\n", flatcc_verify_error_string(ret));
+        return -1;
+    }
+
+    flatcc_builder_aligned_free(buffer);
+    return ret;
+}
+
+int test_doublevec_with_size(flatcc_builder_t *B)
+{
+    void *buffer, *frame;
+    size_t size, size2, esize;
+    int ret;
+
+    gen_doublevec_with_size(B);
+
+    frame = flatcc_builder_finalize_aligned_buffer(B, &size);
+    hexdump("doublevec table with size", frame, size, stderr);
+
+    buffer = flatbuffers_read_size_prefix(frame, &size2);
+    esize = size - sizeof(flatbuffers_uoffset_t);
+    if (size2 != esize) {
+        printf("Size prefix has unexpected size, got %i, expected %i\n", (int)size2, (int)esize);
+        return -1;
+    }
+
+    if ((ret = DoubleVec_verify_as_root(buffer, size))) {
+        printf("doublevec buffer failed to verify, got: %s\n", flatcc_verify_error_string(ret));
+        return -1;
+    }
+
+    flatcc_builder_aligned_free(frame);
+    return ret;
+}
+
+
+int main(int argc, char *argv[])
+{
+    flatcc_builder_t builder, *B;
+
+    (void)argc;
+    (void)argv;
+
+    B = &builder;
+    flatcc_builder_init(B);
+
+#ifdef NDEBUG
+    printf("running optimized doublevec test\n");
+#else
+    printf("running debug doublevec test\n");
+#endif
+#if 1
+    if (test_doublevec(B)) {
+        printf("TEST FAILED\n");
+        return -1;
+    }
+#endif
+#if 1
+    if (test_doublevec_with_size(B)) {
+        printf("TEST FAILED\n");
+        return -1;
+    }
+#endif
+
+    flatcc_builder_clear(B);
+    return 0;
+}

--- a/test/doublevec_test/doublevec_test.fbs
+++ b/test/doublevec_test/doublevec_test.fbs
@@ -1,0 +1,5 @@
+table DoubleVec {
+  a: [double];
+}
+
+root_type DoubleVec;


### PR DESCRIPTION
I believe I have narrowed down the problem with #210 further. It appears to happen only for buffers with size.

I've made new doublevec_test with a very minimal schema and two test cases, one run without size prefix and one with.. the latter fails with "vector header out of range or unaligned".

ctest --verbose output:

```sh
20: doublevec table:
20: 00000000  04 00 00 00 f4 ff ff ff  04 00 00 00 00 00 00 00  |................|
20: 00000010  06 00 08 00 04 00                                 |......|
20: doublevec table with size:
20: 00000000  1a 00 00 00 08 00 00 00  00 00 00 00 f4 ff ff ff  |................|
20: 00000010  04 00 00 00 00 00 00 00  06 00 08 00 04 00        |..............|
20: running debug doublevec test
20: doublevec buffer failed to verify, got: vector header out of range or unaligned
```

The table definition is:

```fbs
table DoubleVec {
  a: [double];
}
```

And the gen code is creating as root and an empty vector for a as it does not seem to matter if I fill it or not with something.

If I create two variants *without* setting the a vector at all both verifies and looks like this:
```sh
1: doublevec table:
1: 00000000  04 00 00 00 fc ff ff ff  04 00 04 00              |............|
1: doublevec table with size:
1: 00000000  0c 00 00 00 04 00 00 00  fc ff ff ff 04 00 04 00  |................|
```