### PR TITLE
Fix use of --schema with --outfile

### DIFF
--- a/src/cli/flatcc_cli.c
+++ b/src/cli/flatcc_cli.c
@@ -456,20 +456,20 @@ int main(int argc, const char *argv[])
     }
     if (opts.bgen_bfbs && cgen) {
         if (opts.gen_stdout) {
-            fprintf(stderr, "--stdout cannot be used with mixed text and binary output");
+            fprintf(stderr, "--stdout cannot be used with mixed text and binary output\n");
             goto fail;
         }
         if (opts.gen_outfile) {
-            fprintf(stderr, "--outfile cannot be used with mixed text and binary output");
+            fprintf(stderr, "--outfile cannot be used with mixed text and binary output\n");
             goto fail;
         }
     }
     if (opts.gen_deptarget && !opts.gen_depfile) {
-        fprintf(stderr, "--deptarget cannot be used without --depfile");
+        fprintf(stderr, "--deptarget cannot be used without --depfile\n");
         goto fail;
     }
     if (opts.gen_stdout && opts.gen_outfile) {
-        fprintf(stderr, "--outfile cannot be used with --stdout");
+        fprintf(stderr, "--outfile cannot be used with --stdout\n");
         goto fail;
     }
     for (i = 0, src = opts.srcpaths; i < opts.srcpath_count; ++i, ++src) {

--- a/src/compiler/codegen_schema.c
+++ b/src/compiler/codegen_schema.c
@@ -478,7 +478,12 @@ static FILE *open_file(fb_options_t *opts, fb_schema_t *S)
     if (opts->gen_stdout) {
         return stdout;
     }
-    checkmem((path = fb_create_join_path_n(prefix, prefix_len, name, len, ext, 1)));
+    if (opts->gen_outfile) {
+        path = fb_create_join_path(prefix, opts->gen_outfile, "", 1);
+    } else {
+        path = fb_create_join_path_n(prefix, prefix_len, name, len, ext, 1);
+    }
+    checkmem(path);
     fp = fopen(path, "wb");
     if (!fp) {
         fprintf(stderr, "error opening file for writing binary schema: %s\n", path);

--- a/src/compiler/flatcc.c
+++ b/src/compiler/flatcc.c
@@ -472,6 +472,11 @@ int flatcc_generate_files(flatcc_context_t ctx)
     }
 #endif
 
+    if (!(P->opts.cgen_reader | P->opts.cgen_builder | P->opts.cgen_verifier
+        | P->opts.cgen_common_reader | P->opts.cgen_common_builder
+        | P->opts.cgen_json_parser | P->opts.cgen_json_printer)) {
+        return 0;
+    }
     if (fb_init_output_c(out, &P->opts)) {
         return -1;
     }


### PR DESCRIPTION
That change has two parts:
 - use the option --outfile when generating binary schema
 - avoid the removal of that created file