### PR TITLE
src/compiler/semantics.c: Fix a warning

### DIFF
--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -1545,7 +1545,7 @@ static int process_enum(fb_parser_t *P, fb_compound_type_t *ct)
     fb_symbol_t *sym, *old, *type_sym;
     fb_member_t *member;
     fb_metadata_t *knowns[KNOWN_ATTR_COUNT];
-    fb_value_t index = { 0 };
+    fb_value_t index = { { { 0 } }, 0, 0 };
     fb_value_t old_index;
     int first = 1;
     int bit_flags = 0;


### PR DESCRIPTION
Fix the following warning with clang.

```
[  7%] Building C object src/compiler/CMakeFiles/flatcc.dir/semantics.c.o
/Users/yamamoto/git/flatcc/src/compiler/semantics.c:1548:26: error: suggest
      braces around initialization of subobject [-Werror,-Wmissing-braces]
    fb_value_t index = { 0 };
                         ^
                         {}
/Users/yamamoto/git/flatcc/src/compiler/semantics.c:1548:26: error: suggest
      braces around initialization of subobject [-Werror,-Wmissing-braces]
    fb_value_t index = { 0 };
                         ^
                         {}
2 errors generated.
```