### PR TITLE
Fix #221 Bad string lenght cause segmentation fault.

### DIFF
--- a/src/runtime/verifier.c
+++ b/src/runtime/verifier.c
@@ -265,7 +265,7 @@ static inline int verify_string(const void *buf, uoffset_t end, uoffset_t base, 
     base += offset;
     n = read_uoffset(buf, base);
     base += offset_size;
-    verify(end - base >= n + 1, flatcc_verify_error_string_out_of_range);
+    verify(end - base > n, flatcc_verify_error_string_out_of_range);
     verify(((uint8_t *)buf + base)[n] == 0, flatcc_verify_error_string_not_zero_terminated);
     return flatcc_verify_ok;
 }


### PR DESCRIPTION
If n = 0xFFFFFFFF then  n + 1 = 0.
end - base (unsigned value) is always greater then 0.
Finally the function test then value (buf + base)[0xFFFFFFFF] whish
crash.