### PR TITLE
Add undefined behaviour sanitizer and fix some undefined behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,10 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     if (FLATCC_IGNORE_CONST_COND)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-tautological-constant-out-of-range-compare")
     endif()
+    if (CMAKE_BUILD_TYPE MATCHES Debug)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+    endif()
 
     # To get assembly output
     # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -save-temps")
@@ -350,4 +354,3 @@ set_target_properties(${dist_targets}
 if (FLATCC_INSTALL)
     install(DIRECTORY include/flatcc DESTINATION include)
 endif()
-

--- a/src/compiler/codegen_c.c
+++ b/src/compiler/codegen_c.c
@@ -165,7 +165,9 @@ int fb_copy_scope(fb_scope_t *scope, char *buf)
         return -1;
     }
     len = (size_t)scope->prefix.len;
-    memcpy(buf, scope->prefix.s, len);
+    if (len > 0) {
+        memcpy(buf, scope->prefix.s, len);
+    }
     for (name = scope->name; name; name = name->link) {
         n = (size_t)name->ident->len;
         memcpy(buf + len, name->ident->text, n);

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -1273,7 +1273,9 @@ static void push_token(fb_parser_t *P, long id, const char *first, const char *l
     size_t offset;
     fb_token_t *t;
 
-    P->te = P->ts + P->tcapacity;
+    if (P->tcapacity) {
+        P->te = P->ts + P->tcapacity;
+    }
     if (P->token == P->te) {
         offset = (size_t)(P->token - P->ts);
         P->tcapacity = P->tcapacity ? 2 * P->tcapacity : 1024;

--- a/src/runtime/builder.c
+++ b/src/runtime/builder.c
@@ -205,7 +205,9 @@ static inline void refresh_ds(flatcc_builder_t *B, uoffset_t type_limit)
 {
     iovec_t *buf = B->buffers + flatcc_builder_alloc_ds;
 
-    B->ds = ds_ptr(B->ds_first);
+    if (B->buffers[flatcc_builder_alloc_ds].iov_base) {
+        B->ds = ds_ptr(B->ds_first);
+    }
     B->ds_limit = (uoffset_t)buf->iov_len - B->ds_first;
     /*
      * So we don't allocate outside tables representation size, nor our


### PR DESCRIPTION
This fixes some instances of undefined behaviour. Specifically:
```
[1/85] Running utility command for gen_monster_test_prefix
/z/flatcc/src/compiler/parser.c:1276:19: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /z/flatcc/src/compiler/parser.c:1276:19 in 

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /z/flatcc/external/hash/cmetrohash.h:62:22 in 
/z/flatcc/src/compiler/codegen_c.c:168:17: runtime error: null pointer passed as argument 2, which is declared to never be null

/z/flatcc/src/runtime/builder.c:208:13: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /z/flatcc/src/runtime/builder.c:208:13 in 
```