### PR TITLE
Use an unsigned type for public interface flags

### DIFF
--- a/include/flatcc/flatcc_builder.h
+++ b/include/flatcc/flatcc_builder.h
@@ -710,10 +710,13 @@ static inline void flatcc_builder_refmap_reset(flatcc_builder_t *B)
 }
 
 
-enum flatcc_builder_buffer_flags {
-    flatcc_builder_is_nested = 1,
-    flatcc_builder_with_size = 2,
-};
+typedef uint16_t flatcc_builder_buffer_flags_t;
+static const flatcc_builder_buffer_flags_t flatcc_builder_is_nested = 1;
+static const flatcc_builder_buffer_flags_t flatcc_builder_with_size = 2;
+
+/* The flag size in the API needs to match the internal size. */
+static_assert(sizeof(flatcc_builder_buffer_flags_t) ==
+              sizeof(((flatcc_builder_t *)0)->buffer_flags), "flag size mismatch");
 
 /**
  * An alternative to start buffer, start struct/table ... end buffer.
@@ -776,7 +779,7 @@ enum flatcc_builder_buffer_flags {
 flatcc_builder_ref_t flatcc_builder_create_buffer(flatcc_builder_t *B,
         const char identifier[FLATBUFFERS_IDENTIFIER_SIZE],
         uint16_t block_align,
-        flatcc_builder_ref_t ref, uint16_t align, int flags);
+        flatcc_builder_ref_t ref, uint16_t align, flatcc_builder_buffer_flags_t flags);
 
 /**
  * Creates a struct within the current buffer without using any
@@ -867,7 +870,7 @@ flatcc_builder_ref_t flatcc_builder_end_struct(flatcc_builder_t *B);
  */
 int flatcc_builder_start_buffer(flatcc_builder_t *B,
         const char identifier[FLATBUFFERS_IDENTIFIER_SIZE],
-        uint16_t block_align, int flags);
+        uint16_t block_align, flatcc_builder_buffer_flags_t flags);
 
 /**
  * The root object should be a struct or a table to conform to the
@@ -923,7 +926,7 @@ flatcc_builder_ref_t flatcc_builder_end_buffer(flatcc_builder_t *B, flatcc_build
  */
 flatcc_builder_ref_t flatcc_builder_embed_buffer(flatcc_builder_t *B,
         uint16_t block_align,
-        const void *data, size_t size, uint16_t align, int flags);
+        const void *data, size_t size, uint16_t align, flatcc_builder_buffer_flags_t flags);
 
 /**
  * Applies to the innermost open buffer. The identifier may be null or

--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -22,13 +22,12 @@ extern "C" {
 #define PDIAGNOSTIC_IGNORE_UNUSED
 #include "flatcc/portable/pdiagnostic_push.h"
 
-enum flatcc_json_parser_flags {
-    flatcc_json_parser_f_skip_unknown = 1,
-    flatcc_json_parser_f_force_add = 2,
-    flatcc_json_parser_f_with_size = 4,
-    flatcc_json_parser_f_skip_array_overflow = 8,
-    flatcc_json_parser_f_reject_array_underflow = 16
-};
+typedef uint32_t flatcc_json_parser_flags_t;
+static const flatcc_json_parser_flags_t flatcc_json_parser_f_skip_unknown = 1;
+static const flatcc_json_parser_flags_t flatcc_json_parser_f_force_add = 2;
+static const flatcc_json_parser_flags_t flatcc_json_parser_f_with_size = 4;
+static const flatcc_json_parser_flags_t flatcc_json_parser_f_skip_array_overflow = 8;
+static const flatcc_json_parser_flags_t flatcc_json_parser_f_reject_array_underflow = 16;
 
 #define FLATCC_JSON_PARSE_ERROR_MAP(XX)                                     \
     XX(ok,                      "ok")                                       \
@@ -92,7 +91,7 @@ typedef struct flatcc_json_parser_ctx flatcc_json_parser_t;
 struct flatcc_json_parser_ctx {
     flatcc_builder_t *ctx;
     const char *line_start;
-    int flags;
+    flatcc_json_parser_flags_t flags;
 #if FLATCC_JSON_PARSE_ALLOW_UNQUOTED
     int unquoted;
 #endif
@@ -111,7 +110,7 @@ static inline int flatcc_json_parser_get_error(flatcc_json_parser_t *ctx)
     return ctx->error;
 }
 
-static inline void flatcc_json_parser_init(flatcc_json_parser_t *ctx, flatcc_builder_t *B, const char *buf, const char *end, int flags)
+static inline void flatcc_json_parser_init(flatcc_json_parser_t *ctx, flatcc_builder_t *B, const char *buf, const char *end, flatcc_json_parser_flags_t flags)
 {
     memset(ctx, 0, sizeof(*ctx));
     ctx->ctx = B;
@@ -872,10 +871,10 @@ const char *flatcc_json_parser_union_type_vector(flatcc_json_parser_t *ctx,
  * `buf`, `bufsiz` may be larger than the parsed json if trailing
  * space or zeroes are expected, but they must represent a valid memory buffer.
  * `fid` must be null, or a valid file identifier.
- * `flags` default to 0. See also `flatcc_json_parser_flags`.
+ * `flags` default to 0. See also `flatcc_json_parser_f_` constants.
  */
 int flatcc_json_parser_table_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx,
-        const char *buf, size_t bufsiz, int flags, const char *fid,
+        const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags, const char *fid,
         flatcc_json_parser_table_f *parser);
 
 /*
@@ -883,7 +882,7 @@ int flatcc_json_parser_table_as_root(flatcc_builder_t *B, flatcc_json_parser_t *
  * root.
  */
 int flatcc_json_parser_struct_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx,
-        const char *buf, size_t bufsiz, int flags, const char *fid,
+        const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags, const char *fid,
         flatcc_json_parser_struct_f *parser);
 
 #include "flatcc/portable/pdiagnostic_pop.h"

--- a/include/flatcc/flatcc_json_printer.h
+++ b/include/flatcc/flatcc_json_printer.h
@@ -243,14 +243,13 @@ static inline void flatcc_json_printer_set_nonstrict(flatcc_json_printer_t *ctx)
     flatcc_json_printer_set_noenum(ctx, 0);
 }
 
-enum flatcc_json_printer_flags {
-    flatcc_json_printer_f_unquote = 1,
-    flatcc_json_printer_f_noenum = 2,
-    flatcc_json_printer_f_skip_default = 4,
-    flatcc_json_printer_f_force_default = 8,
-    flatcc_json_printer_f_pretty = 16,
-    flatcc_json_printer_f_nonstrict = 32,
-};
+typedef uint32_t flatcc_json_printer_flags_t;
+static const flatcc_json_printer_flags_t flatcc_json_printer_f_unquote = 1;
+static const flatcc_json_printer_flags_t flatcc_json_printer_f_noenum = 2;
+static const flatcc_json_printer_flags_t flatcc_json_printer_f_skip_default = 4;
+static const flatcc_json_printer_flags_t flatcc_json_printer_f_force_default = 8;
+static const flatcc_json_printer_flags_t flatcc_json_printer_f_pretty = 16;
+static const flatcc_json_printer_flags_t flatcc_json_printer_f_nonstrict = 32;
 
 /*
  * May be called instead of setting operational modes individually.
@@ -268,7 +267,7 @@ enum flatcc_json_printer_flags {
  * `pretty` flag sets indentation to 2.
  * `nonstrict` implies: `noenum`, `unquote`, `pretty`.
  */
-static inline void flatcc_json_printer_set_flags(flatcc_json_printer_t *ctx, int flags)
+static inline void flatcc_json_printer_set_flags(flatcc_json_printer_t *ctx, flatcc_json_printer_flags_t flags)
 {
     ctx->unquote = !!(flags & flatcc_json_printer_f_unquote);
     ctx->noenum = !!(flags & flatcc_json_printer_f_noenum);

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -1424,7 +1424,7 @@ static int gen_struct_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "return flatcc_json_parser_set_error(ctx, buf, end, flatcc_json_parser_error_runtime);");
     unindent(); println(out, "}");
     println(out, "");
-    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const char *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
+    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags, const char *fid)", snt.text);
     println(out, "{"); indent();
     println(out, "return flatcc_json_parser_struct_as_root(B, ctx, buf, bufsiz, flags, fid, %s_parse_json_struct);",
             snt.text);
@@ -1527,7 +1527,7 @@ static int gen_table_parser(fb_output_t *out, fb_compound_type_t *ct)
     println(out, "return flatcc_json_parser_set_error(ctx, buf, end, flatcc_json_parser_error_runtime);");
     unindent(); println(out, "}");
     println(out, "");
-    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const char *buf, size_t bufsiz, int flags, const char *fid)", snt.text);
+    println(out, "static inline int %s_parse_json_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx, const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags, const char *fid)", snt.text);
     println(out, "{"); indent();
     println(out, "return flatcc_json_parser_table_as_root(B, ctx, buf, bufsiz, flags, fid, %s_parse_json_table);",
             snt.text);
@@ -1661,7 +1661,7 @@ static int gen_root_table_parser(fb_output_t *out, fb_compound_type_t *ct)
 
     println(out, "static int %s_parse_json(flatcc_builder_t *B, flatcc_json_parser_t *ctx,", out->S->basename);
     indent(); indent();
-    println(out, "const char *buf, size_t bufsiz, int flags)");
+    println(out, "const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags)");
     unindent(); unindent();
     println(out, "{"); indent();
     println(out, "flatcc_json_parser_t parser;");
@@ -1767,7 +1767,7 @@ static int gen_json_parser_prototypes(fb_output_t *out)
     println(out, "static int %s_parse_json(flatcc_builder_t *B, flatcc_json_parser_t *ctx,",
             out->S->basename);
     indent(); indent();
-    println(out, "const char *buf, size_t bufsiz, int flags);");
+    println(out, "const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags);");
     unindent(); unindent();
         println(out, "");
         fallthrough;

--- a/src/runtime/builder.c
+++ b/src/runtime/builder.c
@@ -723,11 +723,11 @@ static int align_to_block(flatcc_builder_t *B, uint16_t *align, uint16_t block_a
 
 flatcc_builder_ref_t flatcc_builder_embed_buffer(flatcc_builder_t *B,
         uint16_t block_align,
-        const void *data, size_t size, uint16_t align, int flags)
+        const void *data, size_t size, uint16_t align, flatcc_builder_buffer_flags_t flags)
 {
     uoffset_t size_field, pad;
     iov_state_t iov;
-    int with_size = flags & flatcc_builder_with_size;
+    int with_size = (flags & flatcc_builder_with_size) != 0;
 
     if (align_to_block(B, &align, block_align, !is_top_buffer(B))) {
         return 0;
@@ -744,7 +744,7 @@ flatcc_builder_ref_t flatcc_builder_embed_buffer(flatcc_builder_t *B,
 
 flatcc_builder_ref_t flatcc_builder_create_buffer(flatcc_builder_t *B,
         const char identifier[identifier_size], uint16_t block_align,
-        flatcc_builder_ref_t object_ref, uint16_t align, int flags)
+        flatcc_builder_ref_t object_ref, uint16_t align, flatcc_builder_buffer_flags_t flags)
 {
     flatcc_builder_ref_t buffer_ref;
     uoffset_t header_pad, id_size = 0;
@@ -808,7 +808,7 @@ flatcc_builder_ref_t flatcc_builder_create_struct(flatcc_builder_t *B, const voi
 }
 
 int flatcc_builder_start_buffer(flatcc_builder_t *B,
-        const char identifier[identifier_size], uint16_t block_align, int flags)
+        const char identifier[identifier_size], uint16_t block_align, flatcc_builder_buffer_flags_t flags)
 {
     /*
      * This saves the parent `min_align` in the align field since we
@@ -845,9 +845,9 @@ int flatcc_builder_start_buffer(flatcc_builder_t *B,
 flatcc_builder_ref_t flatcc_builder_end_buffer(flatcc_builder_t *B, flatcc_builder_ref_t root)
 {
     flatcc_builder_ref_t buffer_ref;
-    int flags;
+    flatcc_builder_buffer_flags_t flags;
 
-    flags = B->buffer_flags & flatcc_builder_with_size;
+    flags = (flatcc_builder_buffer_flags_t)B->buffer_flags & flatcc_builder_with_size;
     flags |= is_top_buffer(B) ? 0 : flatcc_builder_is_nested;
     check(frame(type) == flatcc_builder_buffer, "expected buffer frame");
     set_min_align(B, B->block_align);

--- a/src/runtime/json_parser.c
+++ b/src/runtime/json_parser.c
@@ -1263,7 +1263,7 @@ int flatcc_json_parser_table_as_root(flatcc_builder_t *B, flatcc_json_parser_t *
 {
     flatcc_json_parser_t _ctx;
     flatcc_builder_ref_t root;
-    int builder_flags = flags & flatcc_json_parser_f_with_size ? flatcc_builder_with_size : 0;
+    flatcc_builder_buffer_flags_t builder_flags = flags & flatcc_json_parser_f_with_size ? flatcc_builder_with_size : 0;
 
     ctx = ctx ? ctx : &_ctx;
     flatcc_json_parser_init(ctx, B, buf, buf + bufsiz, flags);
@@ -1283,7 +1283,7 @@ int flatcc_json_parser_struct_as_root(flatcc_builder_t *B, flatcc_json_parser_t 
 {
     flatcc_json_parser_t _ctx;
     flatcc_builder_ref_t root;
-    int builder_flags = flags & flatcc_json_parser_f_with_size ? flatcc_builder_with_size : 0;
+    flatcc_builder_buffer_flags_t builder_flags = flags & flatcc_json_parser_f_with_size ? flatcc_builder_with_size : 0;
 
     ctx = ctx ? ctx : &_ctx;
     flatcc_json_parser_init(ctx, B, buf, buf + bufsiz, flags);

--- a/src/runtime/json_parser.c
+++ b/src/runtime/json_parser.c
@@ -1258,7 +1258,7 @@ failed:
 }
 
 int flatcc_json_parser_table_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx,
-        const char *buf, size_t bufsiz, int flags, const char *fid,
+        const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags, const char *fid,
         flatcc_json_parser_table_f *parser)
 {
     flatcc_json_parser_t _ctx;
@@ -1278,7 +1278,7 @@ int flatcc_json_parser_table_as_root(flatcc_builder_t *B, flatcc_json_parser_t *
 }
 
 int flatcc_json_parser_struct_as_root(flatcc_builder_t *B, flatcc_json_parser_t *ctx,
-        const char *buf, size_t bufsiz, int flags, const char *fid,
+        const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags, const char *fid,
         flatcc_json_parser_table_f *parser)
 {
     flatcc_json_parser_t _ctx;

--- a/test/json_test/test_json.c
+++ b/test/json_test/test_json.c
@@ -47,7 +47,7 @@ static const struct test_scope Movie = {
 
 int test_json(const struct test_scope *scope, char *json,
         char *expect, int expect_err,
-        int parse_flags, flatcc_json_printer_flags_t print_flags, int line)
+        flatcc_json_parser_flags_t parse_flags, flatcc_json_printer_flags_t print_flags, int line)
 {
     int ret = -1;
     int err;

--- a/test/json_test/test_json.c
+++ b/test/json_test/test_json.c
@@ -47,7 +47,7 @@ static const struct test_scope Movie = {
 
 int test_json(const struct test_scope *scope, char *json,
         char *expect, int expect_err,
-        int parse_flags, int print_flags, int line)
+        int parse_flags, flatcc_json_printer_flags_t print_flags, int line)
 {
     int ret = -1;
     int err;

--- a/test/json_test/test_json_parser.c
+++ b/test/json_test/test_json_parser.c
@@ -80,7 +80,7 @@ int test_parse(void)
     flatcc_builder_t builder;
     flatcc_builder_t *B = &builder;
     int ret = -1;
-    int flags = 0;
+    flatcc_json_parser_flags_t flags = 0;
 
     flatcc_builder_init(B);
 


### PR DESCRIPTION
When using the provided API to set multiple JSON-printer flags via `flatcc_json_printer_set_flags()`
some compilers and tools will give errors due to a bitwise operation on a signed integer type.

The provided flags are an enum and in C enums are signed (C99 6.4.4.3p2).
Since C doesn't mandate how to represent a negative signed value (one's complement/two's complement/..)
there is no portable way to do bit operations on signed values.

When a user wants to set multiple flags using bitwise OR with the provided flags this gives errors in the user code indicated by tools like clang-tidy. See the checker:
https://releases.llvm.org/10.0.0/tools/clasng/tools/extra/docs/clang-tidy/checks/hicpp-signed-bitwise.html


This PR proposes the use of unsigned int flags instead of an enum,
which avoids having problems in the usercode when using this library.

An example project that triggers the issue:
https://github.com/bjosv/flatcc-experiments/tree/main/issues/enums
see [comment](https://github.com/bjosv/flatcc-experiments/blob/c7d317dae52046b7dcf56a0872db75431f578e09/issues/enums/main.c#L27
).

A C++ reference regarding the use of unsigned types for bit manipulations:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-unsigned
