### PR TITLE
Remove use of the `fallthrough` macro

### DIFF
--- a/include/flatcc/flatcc_json_parser.h
+++ b/include/flatcc/flatcc_json_parser.h
@@ -242,24 +242,38 @@ static inline uint64_t flatcc_json_parser_symbol_part_ext(const char *buf, const
     }
     /* This can bloat inlining for a rarely executed case. */
 #if 1
-    /* Fall through comments needed to silence gcc 7 warnings. */
     switch (n) {
-    case 8: w |= ((uint64_t)buf[7]) << (0 * 8);
-        fallthrough;
-    case 7: w |= ((uint64_t)buf[6]) << (1 * 8);
-        fallthrough;
-    case 6: w |= ((uint64_t)buf[5]) << (2 * 8);
-        fallthrough;
-    case 5: w |= ((uint64_t)buf[4]) << (3 * 8);
-        fallthrough;
-    case 4: w |= ((uint64_t)buf[3]) << (4 * 8);
-        fallthrough;
-    case 3: w |= ((uint64_t)buf[2]) << (5 * 8);
-        fallthrough;
-    case 2: w |= ((uint64_t)buf[1]) << (6 * 8);
-        fallthrough;
-    case 1: w |= ((uint64_t)buf[0]) << (7 * 8);
-        fallthrough;
+    case 8:
+        w |= ((uint64_t)buf[7]) << (0 * 8);
+        goto lbl_n_7;
+    case 7:
+lbl_n_7:
+        w |= ((uint64_t)buf[6]) << (1 * 8);
+        goto lbl_n_6;
+    case 6:
+lbl_n_6:
+        w |= ((uint64_t)buf[5]) << (2 * 8);
+        goto lbl_n_5;
+    case 5:
+lbl_n_5:
+        w |= ((uint64_t)buf[4]) << (3 * 8);
+        goto lbl_n_4;
+    case 4:
+lbl_n_4:
+        w |= ((uint64_t)buf[3]) << (4 * 8);
+        goto lbl_n_3;
+    case 3:
+lbl_n_3:
+        w |= ((uint64_t)buf[2]) << (5 * 8);
+        goto lbl_n_2;
+    case 2:
+lbl_n_2:
+        w |= ((uint64_t)buf[1]) << (6 * 8);
+        goto lbl_n_1;
+    case 1:
+lbl_n_1:
+        w |= ((uint64_t)buf[0]) << (7 * 8);
+        break;
     case 0:
         break;
     }

--- a/include/flatcc/portable/pattributes.h
+++ b/include/flatcc/portable/pattributes.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 #ifndef PORTABLE_EXPOSE_ATTRIBUTES
-#define PORTABLE_EXPOSE_ATTRIBUTES 1
+#define PORTABLE_EXPOSE_ATTRIBUTES 0
 #endif
 
 #ifdef __has_c_attribute

--- a/src/compiler/codegen_c_json_parser.c
+++ b/src/compiler/codegen_c_json_parser.c
@@ -8,8 +8,6 @@
 #include <inttypes.h>
 #endif
 
-#include "flatcc/portable/pattributes.h" /* fallthrough */
-
 #define PRINTLN_SPMAX 64
 static char println_spaces[PRINTLN_SPMAX];
 
@@ -1770,7 +1768,7 @@ static int gen_json_parser_prototypes(fb_output_t *out)
     println(out, "const char *buf, size_t bufsiz, flatcc_json_parser_flags_t flags);");
     unindent(); unindent();
         println(out, "");
-        fallthrough;
+        break;
     default:
         break;
     }

--- a/src/compiler/codegen_c_json_printer.c
+++ b/src/compiler/codegen_c_json_printer.c
@@ -6,8 +6,6 @@
 #include <inttypes.h>
 #endif
 
-#include "flatcc/portable/pattributes.h" /* fallthrough */
-
 static int gen_json_printer_pretext(fb_output_t *out)
 {
     fprintf(out->fp,
@@ -583,7 +581,7 @@ static int gen_json_printer_prototypes(fb_output_t *out)
     fprintf(out->fp,
             "static int %s_print_json(flatcc_json_printer_t *ctx, const char *buf, size_t bufsiz);\n\n",
             out->S->basename);
-        fallthrough;
+        break;
     default:
         break;
     }

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -16,7 +16,6 @@
 #include "codegen.h"
 #include "fileio.h"
 #include "pstrutil.h"
-#include "flatcc/portable/pattributes.h" /* fallthrough */
 #include "flatcc/portable/pparseint.h"
 
 void fb_default_error_out(void *err_ctx, const char *buf, size_t len)
@@ -920,7 +919,7 @@ static void parse_enum_decl(fb_parser_t *P, fb_compound_type_t *ct)
             case tok_kw_float32:
             case tok_kw_float64:
                 error_tok(P, ct->type.t, "integral type expected");
-                fallthrough;
+                break;
             default:
                 break;
             }

--- a/src/compiler/semantics.c
+++ b/src/compiler/semantics.c
@@ -11,8 +11,6 @@
 #include <inttypes.h>
 #endif
 
-#include "flatcc/portable/pattributes.h" /* fallthrough */
-
 /* Same order as enum! */
 static const char *fb_known_attribute_names[] = {
     "",
@@ -525,7 +523,6 @@ static int analyze_struct(fb_parser_t *P, fb_compound_type_t *ct)
         member = (fb_member_t *)sym;
         switch (member->type.type) {
         case vt_fixed_array_type:
-            /* fall through */
         case vt_scalar_type:
             t = member->type.t;
             member->type.st = map_scalar_token_type(t);
@@ -538,7 +535,6 @@ static int analyze_struct(fb_parser_t *P, fb_compound_type_t *ct)
             member->size = size * member->type.len;
             break;
         case vt_fixed_array_compound_type_ref:
-            /* fall through */
         case vt_compound_type_ref:
             /* Enums might not be valid, but then it would be detected earlier. */
             if (member->type.ct->symbol.kind == fb_is_enum) {
@@ -702,8 +698,9 @@ static int process_struct(fb_parser_t *P, fb_compound_type_t *ct)
         switch (member->type.type) {
         case vt_fixed_array_type_ref:
             key_ok = 0;
-            fallthrough;
+            goto lbl_type_ref;
         case vt_type_ref:
+lbl_type_ref:
             type_sym = lookup_type_reference(P, ct->scope, member->type.ref);
             if (!type_sym) {
                 error_ref_sym(P, member->type.ref, "unknown type reference used with struct field", sym);

--- a/src/runtime/json_parser.c
+++ b/src/runtime/json_parser.c
@@ -141,11 +141,10 @@ descend:
         ++buf;
     }
     while (buf != end && *buf <= 0x20) {
-        /* Fall through comments needed to silence gcc 7 warnings. */
         switch (*buf) {
         case 0x0d: buf += (end - buf > 1 && buf[1] == 0x0a);
             /* Consume following LF or treating CR as LF. */
-            fallthrough;
+            ++ctx->line; ctx->line_start = ++buf; continue;
         case 0x0a: ++ctx->line; ctx->line_start = ++buf; continue;
         case 0x09: ++buf; continue;
         case 0x20: goto again; /* Don't consume here, sync with power of 2 spaces. */


### PR DESCRIPTION
Keeping pattributes in the portable library in case the usercode requires it.
The `fallthrough` define is no longer used internally and therefor not defined by default,
i.e PORTABLE_EXPOSE_ATTRIBUTES is not enabled by default.

No `implicit-fallthrough` build errors given in `./scripts/test.sh`

Fixes #247 