### PR TITLE
Enable to build using Clang 15

### DIFF
--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -1593,7 +1593,6 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
     const char *nsc = out->nsc;
     fb_scoped_name_t snt;
     fb_scoped_name_t snref;
-    uint64_t present_id;
     fb_literal_t literal;
     int is_optional;
 
@@ -1629,7 +1628,6 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
     for (sym = ct->members; sym; sym = sym->link) {
         current_key_processed = 0;
         member = (fb_member_t *)sym;
-        present_id = member->id;
         is_primary_key = ct->primary_key == member;
         is_optional = !!(member->flags & fb_fm_optional);
         print_doc(out, "", member->doc);
@@ -1807,7 +1805,6 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                 }
                 break;
             case fb_is_union:
-                present_id--;
                 fprintf(out->fp,
                     "__%sdefine_union_field(%s, %"PRIu64", %s, %.*s, %s, %u)\n",
                     nsc, nsc, (uint64_t)member->id, snt.text, n, s, snref.text, r);
@@ -1833,7 +1830,6 @@ static void gen_table(fb_output_t *out, fb_compound_type_t *ct)
                 break;
             }
             if (member->type.ct->symbol.kind == fb_is_union) {
-                present_id--;
                 fprintf(out->fp,
                     "__%sdefine_union_vector_field(%s, %"PRIu64", %s, %.*s, %s, %u)\n",
                     nsc, nsc, (uint64_t)member->id, snt.text, n, s, snref.text, r);

--- a/test/cgen_test/cgen_test.c
+++ b/test/cgen_test/cgen_test.c
@@ -41,7 +41,7 @@
 #include <string.h>
 #include "flatcc/flatcc.h"
 
-int main()
+int main(void)
 {
     const char *name = "../xyzzy.fbs";
 

--- a/test/json_test/test_basic_parse.c
+++ b/test/json_test/test_basic_parse.c
@@ -277,7 +277,7 @@ fail:
     return buf;
 }
 
-int main()
+int main(void)
 {
     int ret = -1;
     flatcc_builder_t builder;

--- a/test/json_test/test_json.c
+++ b/test/json_test/test_json.c
@@ -582,7 +582,7 @@ int fixed_array_tests(void)
  * covered in the printer and parser tests using the golden data
  * set.
  */
-int main()
+int main(void)
 {
     BEGIN_TEST(Monster);
 


### PR DESCRIPTION
The diagnostics in Clang 15 is [stricter](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics) and finds some issues.

- [-Werror,-Wstrict-prototypes]
  Using a strict prototype for some main()'s in the test code.

- [-Werror,-Wunused-but-set-variable]
  The variable 'present_id' is set but not used, so removed.

Some details: https://reviews.llvm.org/D122895