### PR TITLE
Install required gcc version in weekly CI for macOS

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -148,6 +148,9 @@ jobs:
         gcc-version: [9, 12]
     steps:
       - uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          brew install gcc@${{ matrix.gcc-version }}
       - name: Build and run tests
         env:
           CC: gcc-${{ matrix.gcc-version }}


### PR DESCRIPTION
gcc-9 was removed from Githubs macOS runner via https://github.com/actions/runner-images/issues/7136
This PR adds a prepare step which installs the required gcc version.

[Here](https://github.com/Nordix/flatcc/actions/runs/4828087072) is a forced run.