### PR TITLE
Update the apt key for Intel compilers in weekly CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -112,8 +112,10 @@ jobs:
     steps:
       - name: Prepare
         run: |
-          wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | sudo apt-key add -
-          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+            gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+            sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
           sudo apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2021.4.0
       - name: Setup Intel oneAPI


### PR DESCRIPTION
The weekly CI job that builds with Intel compilers now downloads and uses the [recommended keyfile](https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-2/apt.html) for Intels APT repository.
This should fix failing weekly runs.

We also replace the deprecated `apt-key` command with `gpg  --dearmor` which is generally recommended.
`apt-key` has security flaws and will be removed after Ubuntu 22.04.
This change follows [Intels installation guide](https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-2/apt.html).

Logs from a forced run of this PR can be found [here](https://github.com/Nordix/flatcc/actions/runs/6407705818/job/17395072085).