### PR TITLE
Check for C standard version >= 23 for [[__fallthrough__]]

### DIFF
--- a/include/flatcc/portable/pattributes.h
+++ b/include/flatcc/portable/pattributes.h
@@ -57,7 +57,7 @@ extern "C" {
 
 
 /* https://en.cppreference.com/w/c/language/attributes/fallthrough */
-#if PORTABLE_HAS_C_ATTRIBUTE(__fallthrough__)
+#if PORTABLE_HAS_C_ATTRIBUTE(__fallthrough__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 # define pattribute_fallthrough [[__fallthrough__]]
 #elif PORTABLE_HAS_ATTRIBUTE(__fallthrough__)
 # define pattribute_fallthrough __attribute__((__fallthrough__))


### PR DESCRIPTION
This avoids warnings with clang-18+ e.g.

pprintint.h:256:6: error: [[]] attributes are a C23 extension [-Werror,-Wc23-extensions]