### PR TITLE
CI: updates to Weekly build

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.14
+        uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: 2.8.12
       - uses: actions/checkout@v4

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang-version: [5, 7, 9, 11, 13, 15]
+        clang-version: [5, 7, 9, 11, 13, 15, 17]
     steps:
       - name: Setup Clang
         uses: aminya/setup-cpp@v1
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc-version: [7, 9, 11]
+        gcc-version: [7, 9, 11, 13]
     steps:
       - name: Setup GCC
         uses: aminya/setup-cpp@v1


### PR DESCRIPTION
- Fix warning "Node.js 16 actions are deprecated"
   Start using version `v2` of `actions-setup-cmake` which runs on Node.js 20.

- Add the latest `clang` and `gcc`,  the versions given by aminya/setup-cpp are:
    - gcc-13.1
    - clang-17.0.6

An [example](https://github.com/Nordix/flatcc/actions/runs/8268239669) run.

Note: an intermittent warning have been seen from the action `aminya/setup-cpp`, see https://github.com/aminya/setup-cpp/issues/234