### PR TITLE
Improve Github repository security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Automated dependency updates.
+#
+# For configuration options see:
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu-ninja-clang:
     name: Ubuntu (ninja, clang)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install ninja-build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         env:
           CC: clang
@@ -26,7 +26,7 @@ jobs:
     name: Ubuntu (make, gcc)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         env:
           CC: gcc
@@ -42,7 +42,7 @@ jobs:
       - name: Prepare
         run: |
           brew install cmake ninja
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           scripts/test.sh
@@ -51,8 +51,8 @@ jobs:
     name: Windows
     runs-on: windows-2022
     steps:
-      - uses: microsoft/setup-msbuild@v2
-      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           cmake .

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,6 +8,9 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
 
+permissions:
+  contents: read
+
 jobs:
   clang:
     name: Clang ${{ matrix.clang-version }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,10 +18,10 @@ jobs:
         clang-version: [5, 7, 9, 11, 13, 15, 17]
     steps:
       - name: Setup Clang
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@290824452986e378826155f3379d31bce8753d76 # v0.37.0
         with:
           llvm: ${{ matrix.clang-version }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gcc-multilib g++-multilib
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         env:
           CC: clang
@@ -61,7 +61,7 @@ jobs:
           sudo dpkg -i ./cpp-4.4_4.4.7-8ubuntu1_amd64.deb
           sudo dpkg -i ./gcc-4.4_4.4.7-8ubuntu1_amd64.deb
           sudo dpkg -i ./libstdc++6-4.4-dev_4.4.7-8ubuntu1_amd64.deb ./g++-4.4_4.4.7-8ubuntu1_amd64.deb
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         env:
           CC: gcc-4.4
@@ -79,10 +79,10 @@ jobs:
         gcc-version: [7, 9, 11, 13]
     steps:
       - name: Setup GCC
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@290824452986e378826155f3379d31bce8753d76 # v0.37.0
         with:
           gcc: ${{ matrix.gcc-version }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -96,7 +96,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gcc-multilib g++-multilib
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-32bit
@@ -122,7 +122,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         env:
           CC: ${{ matrix.compiler }}
@@ -135,7 +135,7 @@ jobs:
     name: macOS Clang
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -149,7 +149,7 @@ jobs:
       matrix:
         gcc-version: [9, 12]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Prepare
         run: |
           brew install gcc@${{ matrix.gcc-version }}
@@ -169,8 +169,8 @@ jobs:
       matrix:
         version: [2019, 2022]
     steps:
-      - uses: microsoft/setup-msbuild@v2
-      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           cmake .
@@ -182,10 +182,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: 2.8.12
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Build and run tests
         run: |
           cmake --version


### PR DESCRIPTION
This PR updates our CI setup according to the secure software development best practices
recommended by the Open Source Security Foundation ([OpenSSF](https://openssf.org/)).
The overall goal is to strengthen the (supply chain) security posture.

The following changes are included:
- Pin the Github Action dependencies to hash.
When developing a CI workflow, it's common to version-pin dependencies (i.e. `actions/checkout@v4`). However, version tags are mutable, so a malicious attacker could overwrite a version tag to point to a malicious or vulnerable commit instead.
Pinning workflow dependencies by hash ensures the dependency is immutable and its behavior is guaranteed.
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

- Set the default permission for CI workflows to only be able to read from the repository (scope: `contents`).
A compromised action will not be able to modify the repo or even steal secrets since all other permission-scopes are implicit set to "none", i.e. not permitted.
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

- Add a [dependabot](https://docs.github.com/en/code-security/dependabot) which will perform weekly checks of the Github actions used in CI.
When a newer version is found a pull request is opened to suggest a lift.
https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool

For future reference, additional Github [guidelines](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) and info about [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions).