### PR TITLE
Replace `macos-11` runner in CI since it's deprecated

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang-version: [5, 7, 9, 11, 13, 15, 17]
+        clang-version: [5, 7, 9, 11, 13, 15, 17, 18]
     steps:
       - name: Setup Clang
         uses: aminya/setup-cpp@290824452986e378826155f3379d31bce8753d76 # v0.37.0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -136,7 +136,7 @@ jobs:
 
   macos-clang:
     name: macOS Clang
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Build and run tests
@@ -146,11 +146,11 @@ jobs:
 
   macos-gcc:
     name: macOS GCC ${{ matrix.gcc-version }}
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
-        gcc-version: [9, 12]
+        gcc-version: [10, 13]
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Prepare


### PR DESCRIPTION
The macOS 11 runner image will soon be removed (2024-06-24) according to [github.blog](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal), so lets replace `macos-11` with `macos-12`. The gcc versions used in the CI job `macos-gcc` are also lifted since `gcc-9` wont run on `macos-12` (due to macosx-version-min).

This PR also adds the latest release of `clang` to CI.

A weekly run:
https://github.com/Nordix/flatcc/actions/runs/9172372095
