### PR TITLE
Separate CI jobs for macOS on x86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: Prepare
         run: |
-          brew install cmake ninja
+          brew install ninja
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Build and run tests
         run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -135,8 +135,12 @@ jobs:
           scripts/test.sh
 
   macos-clang:
-    name: macOS Clang
-    runs-on: macos-12
+    name: macOS Clang (${{ matrix.runner == 'macos-13' && 'x86_64' || 'arm64' }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-13, macos-14]
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Build and run tests
@@ -145,12 +149,23 @@ jobs:
           scripts/test.sh
 
   macos-gcc:
-    name: macOS GCC ${{ matrix.gcc-version }}
-    runs-on: macos-12
+    name: macOS GCC ${{ matrix.gcc-version }} (${{ matrix.runner == 'macos-13' && 'x86_64' || 'arm64' }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        gcc-version: [10, 13]
+        include:
+          - runner: macos-13
+            gcc-version: 10
+          - runner: macos-13
+            gcc-version: 13
+            xcode-version: 14.3 # Required by prebuilt GCC 13.3 (15.0 default)
+
+          - runner: macos-14
+            gcc-version: 11 # First version available on arm64
+          - runner: macos-14
+            gcc-version: 13
+            xcode-version: 15.3 # Required by prebuilt GCC 13.3 (15.0 default)
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Prepare
@@ -158,8 +173,10 @@ jobs:
           # Install gcc if not already available.
           brew list gcc@${{ matrix.gcc-version }} &>/dev/null || \
             brew install gcc@${{ matrix.gcc-version }}
-          # Switch to a working Xcode version.
-          sudo xcode-select -s /Applications/Xcode_14.0.app/Contents/Developer
+      - name: Switch to a working Xcode version
+        if: ${{ matrix.xcode-version }}
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
       - name: Build and run tests
         env:
           CC: gcc-${{ matrix.gcc-version }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -167,8 +167,7 @@ jobs:
         run: |
           # Install gcc if not already available.
           brew list gcc@${{ matrix.gcc-version }} &>/dev/null || \
-            brew update && \
-            brew install gcc@${{ matrix.gcc-version }}
+            (brew update && brew install gcc@${{ matrix.gcc-version }})
       - name: Build and run tests
         env:
           CC: gcc-${{ matrix.gcc-version }}
@@ -190,8 +189,7 @@ jobs:
         run: |
           # Install gcc if not already available.
           brew list gcc@${{ matrix.gcc-version }} &>/dev/null || \
-            brew update && \
-            brew install gcc@${{ matrix.gcc-version }}
+            (brew update && brew install gcc@${{ matrix.gcc-version }})
       - name: Build and run tests
         env:
           CC: gcc-${{ matrix.gcc-version }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -155,7 +155,11 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Prepare
         run: |
-          brew install gcc@${{ matrix.gcc-version }}
+          # Install gcc if not already available.
+          brew list gcc@${{ matrix.gcc-version }} &>/dev/null || \
+            brew install gcc@${{ matrix.gcc-version }}
+          # Switch to a working Xcode version.
+          sudo xcode-select -s /Applications/Xcode_14.0.app/Contents/Developer
       - name: Build and run tests
         env:
           CC: gcc-${{ matrix.gcc-version }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -135,12 +135,18 @@ jobs:
           scripts/test.sh
 
   macos-clang:
-    name: macOS Clang (${{ matrix.runner == 'macos-13' && 'x86_64' || 'arm64' }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [macos-13, macos-14]
+    name: macOS Clang
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Build and run tests
+        run: |
+          scripts/initbuild.sh make-concurrent
+          scripts/test.sh
+
+  macos-clang-x86:
+    name: macOS Clang (x86)
+    runs-on: macos-13 # Last macos x86 runner
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Build and run tests
@@ -149,34 +155,43 @@ jobs:
           scripts/test.sh
 
   macos-gcc:
-    name: macOS GCC ${{ matrix.gcc-version }} (${{ matrix.runner == 'macos-13' && 'x86_64' || 'arm64' }})
-    runs-on: ${{ matrix.runner }}
+    name: macOS GCC ${{ matrix.gcc-version }}
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: macos-13
-            gcc-version: 10
-          - runner: macos-13
-            gcc-version: 13
-            xcode-version: 14.3 # Required by prebuilt GCC 13.3 (15.0 default)
-
-          - runner: macos-14
-            gcc-version: 11 # First version available on arm64
-          - runner: macos-14
-            gcc-version: 13
-            xcode-version: 15.3 # Required by prebuilt GCC 13.3 (15.0 default)
+        gcc-version: [11, 14]
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Prepare
         run: |
           # Install gcc if not already available.
           brew list gcc@${{ matrix.gcc-version }} &>/dev/null || \
+            brew update && \
             brew install gcc@${{ matrix.gcc-version }}
-      - name: Switch to a working Xcode version
-        if: ${{ matrix.xcode-version }}
+      - name: Build and run tests
+        env:
+          CC: gcc-${{ matrix.gcc-version }}
+          CXX: g++-${{ matrix.gcc-version }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+          scripts/initbuild.sh make-concurrent
+          scripts/test.sh
+
+  macos-gcc-x86:
+    name: macOS GCC ${{ matrix.gcc-version }} (x86)
+    runs-on: macos-13 # Last macos x86 runner
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc-version: [10, 14]
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Prepare
+        run: |
+          # Install gcc if not already available.
+          brew list gcc@${{ matrix.gcc-version }} &>/dev/null || \
+            brew update && \
+            brew install gcc@${{ matrix.gcc-version }}
       - name: Build and run tests
         env:
           CC: gcc-${{ matrix.gcc-version }}


### PR DESCRIPTION
Split the CI jobs for testing Mac to run on both "old" x86 runners and the new M1 runner.

The pre-installed gcc 13.3 (brew package `gcc-13`) only seems to work with an older MacOSX.sdk version than the [default](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode) in a macos-12 runner.
Lets update to `gcc-14` which has been corrected to be able to use any SDK version.

This PR also adds a check if the compiler is already installed, which silences a warning.

Weekly run:
https://github.com/Nordix/flatcc/actions/runs/9413941834