### PR TITLE
Use supported GCC versions in weekly CI for macOS

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc-version: [11, 14]
+        gcc-version: [12, 14] # Github supports the 3 latest major versions.
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Prepare
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc-version: [10, 14]
+        gcc-version: [12, 14] # Github supports the 3 latest major versions.
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Prepare


### PR DESCRIPTION
Since gcc@11 suddenly started to fail on runner `macos-14` due to a non-matching default Xcode version;
lets only use supported versions of GCC in the macOS weekly runs.
These GCC versions are more likely verified to work fine on runners.

Only the 3 latest versions of GCC are supported, i.e. GCC 12, 13 and 14 according to
https://github.com/actions/runner-images/issues/10213 and https://github.com/actions/runner-images#software-and-image-support .

Manual run: https://github.com/Nordix/flatcc/actions/runs/10418446489