### PR TITLE
Revert "Bump aminya/setup-cpp from 0.39.0 to 0.41.0"

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,7 +21,7 @@ jobs:
         clang-version: [5, 7, 9, 11, 13, 15, 17, 18]
     steps:
       - name: Setup Clang
-        uses: aminya/setup-cpp@bfbfe9ca0b2c69a076f6513393d61fc478fb54f8 # v0.41.0
+        uses: aminya/setup-cpp@6827680827d3638bbf0bf654901b95f16258a412 # v0.39.0
         with:
           llvm: ${{ matrix.clang-version }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -82,7 +82,7 @@ jobs:
         gcc-version: [7, 9, 11, 13]
     steps:
       - name: Setup GCC
-        uses: aminya/setup-cpp@bfbfe9ca0b2c69a076f6513393d61fc478fb54f8 # v0.41.0
+        uses: aminya/setup-cpp@6827680827d3638bbf0bf654901b95f16258a412 # v0.39.0
         with:
           gcc: ${{ matrix.gcc-version }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
Investigated the issue with the weekly CI runs failing and created this issue:  https://github.com/aminya/setup-cpp/issues/295
Lets revert this version to the older version that used a more accepting client while downloading llvm packages.
Maybe the issue is temporary but lets use the older version until I can make sure, or the issue is fixed in setup-cpp.

Reverts dvidelabs/flatcc#294