### PR TITLE
consider length of string keys

### DIFF
--- a/external/hash/str_set.c
+++ b/external/hash/str_set.c
@@ -47,7 +47,7 @@ DEFINE_HASH_TABLE(str_set)
  */
 static inline int ht_match(const void *key, size_t len, str_set_item_t item)
 {
-    return len == strlen(item) && strncmp(key, item, len) == 0;
+    return strncmp(key, item, len) == 0 && item[len] == '\0';
 }
 
 static inline const void *ht_key(str_set_item_t item)

--- a/external/hash/str_set.c
+++ b/external/hash/str_set.c
@@ -47,7 +47,7 @@ DEFINE_HASH_TABLE(str_set)
  */
 static inline int ht_match(const void *key, size_t len, str_set_item_t item)
 {
-    return strncmp(key, item, len) == 0;
+    return len == strlen(item) && strncmp(key, item, len) == 0;
 }
 
 static inline const void *ht_key(str_set_item_t item)


### PR DESCRIPTION
take length of keys in the str_set hash into account so keys which are perfect sub-strings do not match incorrectly