### PR TITLE
runtime/CMakeLists.txt: Use target_include_directories

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,7 +1,3 @@
-include_directories (
-    "${PROJECT_SOURCE_DIR}/include"
-)
-
 add_library(flatccrt
     builder.c
     emitter.c
@@ -10,6 +6,9 @@ add_library(flatccrt
     json_parser.c
     json_printer.c
 )
+
+target_include_directories(flatccrt PUBLIC
+    "${PROJECT_SOURCE_DIR}/include")
 
 if (FLATCC_INSTALL)
     install(TARGETS flatccrt DESTINATION ${lib_dir})


### PR DESCRIPTION
Otherwise, include directories are not propagated to targets calling `target_link_libraries()`.