### PR TITLE
Remove a few misleading-indentation warnings

### DIFF
--- a/src/compiler/codegen_c_builder.c
+++ b/src/compiler/codegen_c_builder.c
@@ -287,7 +287,7 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "  _uvref.type = flatcc_builder_refmap_find(B, vec.type); _uvref.value = flatcc_builder_refmap_find(B, vec.value);\\\n"
         "  _len = N ## _union_vec_len(vec); if (_uvref.type == 0) {\\\n"
         "  _uvref.type = flatcc_builder_refmap_insert(B, vec.type, (flatcc_builder_create_type_vector(B, vec.type, _len))); }\\\n"
-        "  if (_uvref.type == 0) return _ret; if (_uvref.value == 0) {\\\n"
+        "  if (_uvref.type == 0) { return _ret; } if (_uvref.value == 0) {\\\n"
         "  if (flatcc_builder_start_offset_vector(B)) return _ret;\\\n"
         "  for (_i = 0; _i < _len; ++_i) { _uref = N ## _clone(B, N ## _union_vec_at(vec, _i));\\\n"
         "    if (!_uref.value || !(flatcc_builder_offset_vector_push(B, _uref.value))) return _ret; }\\\n"
@@ -416,11 +416,11 @@ int fb_gen_common_c_builder_header(fb_output_t *out)
         "static inline T *N ## _array_copy(T *p, const T *p2, size_t n)\\\n"
         "{ memcpy(p, p2, n * sizeof(T)); return p; }\\\n"
         "static inline T *N ## _array_copy_from_pe(T *p, const T *p2, size_t n)\\\n"
-        "{ size_t i; if (NS ## is_native_pe()) memcpy(p, p2, n * sizeof(T)); else\\\n"
-        "  for (i = 0; i < n; ++i) N ## _copy_from_pe(&p[i], &p2[i]); return p; }\\\n"
+        "{ size_t i; if (NS ## is_native_pe()) memcpy(p, p2, n * sizeof(T)); else {\\\n"
+        "  for (i = 0; i < n; ++i) N ## _copy_from_pe(&p[i], &p2[i]); } return p; }\\\n"
         "static inline T *N ## _array_copy_to_pe(T *p, const T *p2, size_t n)\\\n"
-        "{ size_t i; if (NS ## is_native_pe()) memcpy(p, p2, n * sizeof(T)); else\\\n"
-        "  for (i = 0; i < n; ++i) N ## _copy_to_pe(&p[i], &p2[i]); return p; }\n",
+        "{ size_t i; if (NS ## is_native_pe()) memcpy(p, p2, n * sizeof(T)); else {\\\n"
+        "  for (i = 0; i < n; ++i) N ## _copy_to_pe(&p[i], &p2[i]); } return p; }\n",
         nsc);
     fprintf(out->fp,
         "#define __%sdefine_scalar_primitives(NS, N, T)\\\n"

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -289,7 +289,7 @@ static void gen_union(fb_output_t *out)
         "__## NS ## field_present(ID, t__tmp)\\\n"
         "static inline T ## _union_t N ## _ ## NK ## _union(N ## _table_t t__tmp)\\\n"
         "{ T ## _union_t u__tmp = { 0, 0 }; u__tmp.type = N ## _ ## NK ## _type_get(t__tmp);\\\n"
-        "  if (u__tmp.type == 0) return u__tmp; u__tmp.value = N ## _ ## NK ## _get(t__tmp); return u__tmp; }\\\n"
+        "  if (u__tmp.type == 0) { return u__tmp; } u__tmp.value = N ## _ ## NK ## _get(t__tmp); return u__tmp; }\\\n"
         "static inline NS ## string_t N ## _ ## NK ## _as_string(N ## _table_t t__tmp)\\\n"
         "{ return NS ## string_cast_from_generic(N ## _ ## NK ## _get(t__tmp)); }\\\n"
         "\n");


### PR DESCRIPTION
Remove two GCC (tested on 13.2.0) warnings from code.

I believe if accepted would be good also to put to the pregenerated ones (in `include/flatcc/reflection/`), but I didn't do that as I supposed maintainer takes usually care of that :-) (can add to PR if needed!)

Example output I see:
```
/home/foo/bar/generated/flatbuffers_common_builder.h: In function 'flatbuffers_char_array_copy_from_pe':
/home/foo/bar/generated/flatbuffers_common_builder.h:341:3: error: this 'for' clause does not guard... [-Werror=misleading-indentation]
  341 |   for (i = 0; i < n; ++i) N ## _copy_from_pe(&p[i], &p2[i]); return p; }\
      |   ^~~
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:341:62: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'for'
  341 |   for (i = 0; i < n; ++i) N ## _copy_from_pe(&p[i], &p2[i]); return p; }\
      |                                                              ^~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:340:69: error: this 'else' clause does not guard... [-Werror=misleading-indentation]
  340 | { size_t i; if (NS ## is_native_pe()) memcpy(p, p2, n * sizeof(T)); else\
      |                                                                     ^~~~~
  341 |   for (i = 0; i < n; ++i) N ## _copy_from_pe(&p[i], &p2[i]); return p; }\
      |                                                                      
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:341:62: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
  341 |   for (i = 0; i < n; ++i) N ## _copy_from_pe(&p[i], &p2[i]); return p; }\
      |                                                              ^~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h: In function 'flatbuffers_char_array_copy_to_pe':
/home/foo/bar/generated/flatbuffers_common_builder.h:344:3: error: this 'for' clause does not guard... [-Werror=misleading-indentation]
  344 |   for (i = 0; i < n; ++i) N ## _copy_to_pe(&p[i], &p2[i]); return p; }
      |   ^~~
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:344:60: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'for'
  344 |   for (i = 0; i < n; ++i) N ## _copy_to_pe(&p[i], &p2[i]); return p; }
      |                                                            ^~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:343:69: error: this 'else' clause does not guard... [-Werror=misleading-indentation]
  343 | { size_t i; if (NS ## is_native_pe()) memcpy(p, p2, n * sizeof(T)); else\
      |                                                                     ^~~~~
  344 |   for (i = 0; i < n; ++i) N ## _copy_to_pe(&p[i], &p2[i]); return p; }
      |                                                                      
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:344:60: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
  344 |   for (i = 0; i < n; ++i) N ## _copy_to_pe(&p[i], &p2[i]); return p; }
      |                                                            ^~~~~~
/home/foo/bar/generated/flatbuffers_common_builder.h:360:1: note: in expansion of macro '__flatbuffers_define_fixed_array_primitives'
  360 | __ ## NS ## define_fixed_array_primitives(NS, N, T)\
      | ^~
/home/foo/bar/generated/flatbuffers_common_builder.h:668:1: note: in expansion of macro '__flatbuffers_build_scalar'
  668 | __flatbuffers_build_scalar(flatbuffers_, flatbuffers_char, char)

```