### PR TITLE
bump the minimum version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
-# Ubuntu 14.04 (Trusty)
-cmake_minimum_required (VERSION 2.8.12.2)
-# Centos 7
-#cmake_minimum_required (VERSION 2.8.11)
-#cmake_minimum_required (VERSION 2.8)
+# CMake minimal version.
+cmake_minimum_required (VERSION 3.25)
 
 # Experimental for generating compile_commands.json so editors with
 # clangd language server support can use it. Symlink

--- a/external/hash/CMakeLists.txt
+++ b/external/hash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.25)
 
 project (HashTest)
 


### PR DESCRIPTION
This commit bumps the minimum version of CMake in CMakeLists.txt files.

The version of CMake in Ubuntu LTS is 3.28 and in CentOS is 3.26. Then, the version of CMake is set to 3.25 arbitrary.