### PR TITLE
fix argument type in fprintf

### DIFF
--- a/src/compiler/codegen_c_json_printer.c
+++ b/src/compiler/codegen_c_json_printer.c
@@ -301,7 +301,7 @@ static int gen_json_printer_struct(fb_output_t *out, fb_compound_type_t *ct)
             tp = scalar_type_prefix(member->type.st);
             fprintf(
                     out->fp,
-                    "    flatcc_json_printer_%s_array_struct_field(ctx, %d, p, %"PRIu64", \"%.*s\", %ld, %d);\n",
+                    "    flatcc_json_printer_%s_array_struct_field(ctx, %d, p, %"PRIu64", \"%.*s\", %ld, %lu);\n",
                     tp, index, (uint64_t)member->offset, (int)sym->ident->len, sym->ident->text, sym->ident->len, member->type.len);
             break;
         case vt_fixed_array_compound_type_ref:
@@ -311,7 +311,7 @@ static int gen_json_printer_struct(fb_output_t *out, fb_compound_type_t *ct)
 #if FLATCC_JSON_PRINT_MAP_ENUMS
                 tp = scalar_type_prefix(member->type.ct->type.st);
                 fprintf(out->fp,
-                        "    flatcc_json_printer_%s_enum_array_struct_field(ctx, %d, p, %"PRIu64", \"%.*s\", %ld, %d, %s_print_json_enum);\n",
+                        "    flatcc_json_printer_%s_enum_array_struct_field(ctx, %d, p, %"PRIu64", \"%.*s\", %ld, %lu, %s_print_json_enum);\n",
                         tp, index, (uint64_t)member->offset, (int)sym->ident->len, sym->ident->text, sym->ident->len, member->type.len, snref.text);
                 break;
 #else

--- a/src/compiler/codegen_c_reader.c
+++ b/src/compiler/codegen_c_reader.c
@@ -1294,7 +1294,7 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
             tname = scalar_type_name(member->type.st);
             tname_prefix = scalar_type_prefix(member->type.st);
             fprintf(out->fp,
-                "__%sdefine_struct_scalar_fixed_array_field(%s, %.*s, %s%s, %s%s, %d)\n",
+                "__%sdefine_struct_scalar_fixed_array_field(%s, %.*s, %s%s, %s%s, %lu)\n",
                 nsc, snt.text, n, s, nsc, tname_prefix, tname_ns, tname, member->type.len);
             /* TODO: if member->type.st == fb_char add string specific methods. */
             break;
@@ -1344,12 +1344,12 @@ static void gen_struct(fb_output_t *out, fb_compound_type_t *ct)
             switch (member->type.ct->symbol.kind) {
             case fb_is_enum:
                 fprintf(out->fp,
-                    "__%sdefine_struct_scalar_fixed_array_field(%s, %.*s, %s, %s_enum_t, %d)\n",
+                    "__%sdefine_struct_scalar_fixed_array_field(%s, %.*s, %s, %s_enum_t, %lu)\n",
                     nsc, snt.text, n, s, snref.text, snref.text, member->type.len);
                 break;
             case fb_is_struct:
                 fprintf(out->fp,
-                    "__%sdefine_struct_struct_fixed_array_field(%s, %.*s, %s_struct_t, %d)\n",
+                    "__%sdefine_struct_struct_fixed_array_field(%s, %.*s, %s_struct_t, %lu)\n",
                     nsc, snt.text, n, s, snref.text, member->type.len);
                 break;
             }


### PR DESCRIPTION
This commit fixes the argument type of member->type.len, which is a uint32_t and not an int.