### PR TITLE
flatbuffer reading support for windows kernelland

### DIFF
--- a/include/flatcc/flatcc_endian.h
+++ b/include/flatcc/flatcc_endian.h
@@ -45,7 +45,7 @@ extern "C" {
  * configuration.
  */
 
-#ifndef UINT8_t
+#ifndef UINT8_MAX
 #include <stdint.h>
 #endif
 

--- a/include/flatcc/portable/pstdint.h
+++ b/include/flatcc/portable/pstdint.h
@@ -197,7 +197,7 @@
  *  do nothing else.  On the Mac OS X version of gcc this is _STDINT_H_.
  */
 
-#if ((defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (__GNUC__ > 3 || defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)) )) && !defined (_PSTDINT_H_INCLUDED)
+#if ((defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined (__WATCOMC__) && (defined (_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (__GNUC__ > 3 || defined(_STDINT_H) || defined(_STDINT_H_) || defined (__UINT_FAST64_TYPE__)) )) && !defined (_PSTDINT_H_INCLUDED) && !defined (NTDDI_VERSION)
 #include <stdint.h>
 #define _PSTDINT_H_INCLUDED
 # if defined(__GNUC__) && (defined(__x86_64__) || defined(__ppc64__)) && !(defined(__APPLE__) && defined(__MACH__))


### PR DESCRIPTION
Tinkered a bit to allow reading of flatbuffers without stdlib, obviously you'll need to define the stdint types and `#defines` in your build environment.

Very much a new contributor to open source so apologies in advance