### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   ubuntu-ninja-clang:
     name: Ubuntu (ninja, clang)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Prepare
         run: |
@@ -27,7 +27,7 @@ jobs:
 
   ubuntu-make-gcc:
     name: Ubuntu (make, gcc)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build and run tests

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,7 +21,7 @@ jobs:
         clang-version: [5, 7, 9, 11, 13, 15, 17, 18]
     steps:
       - name: Setup Clang
-        uses: aminya/setup-cpp@cb3bbf182c8d22fef33ae35d1d954341bb31ce96 # v0.40.0
+        uses: aminya/setup-cpp@17c11551771948abc5752bbf3183482567c7caf0 # v1.1.1
         with:
           llvm: ${{ matrix.clang-version }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,7 +82,7 @@ jobs:
         gcc-version: [7, 9, 11, 13]
     steps:
       - name: Setup GCC
-        uses: aminya/setup-cpp@cb3bbf182c8d22fef33ae35d1d954341bb31ce96 # v0.40.0
+        uses: aminya/setup-cpp@17c11551771948abc5752bbf3183482567c7caf0 # v1.1.1
         with:
           gcc: ${{ matrix.gcc-version }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   clang:
     name: Clang ${{ matrix.clang-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
 
   clang-32bit:
     name: Clang 32bit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Prepare
         run: |
@@ -49,7 +49,7 @@ jobs:
 
   gcc-old:
     name: GCC 4.4
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup GCC
         run: |
@@ -75,7 +75,7 @@ jobs:
 
   gcc:
     name: GCC ${{ matrix.gcc-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -93,7 +93,7 @@ jobs:
 
   gcc-32bit:
     name: GCC 32bit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Prepare
         run: |
@@ -216,7 +216,7 @@ jobs:
 
   cmake-minimum-required:
     name: CMake 2.8.12 (min. required)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -107,7 +107,7 @@ jobs:
 
   intel:
     name: Intel ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +120,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
             sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
-          sudo apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2021.4.0
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.4
       - name: Setup Intel oneAPI
         run: |
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang-version: [5, 7, 9, 11, 13, 15, 17, 18]
+        clang-version: [5, 7, 9, 11, 13, 15, 17, 18, 19]
     steps:
       - name: Setup Clang
         uses: aminya/setup-cpp@17c11551771948abc5752bbf3183482567c7caf0 # v1.1.1
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc-version: [7, 9, 11, 13]
+        gcc-version: [9, 11, 13, 14]
     steps:
       - name: Setup GCC
         uses: aminya/setup-cpp@17c11551771948abc5752bbf3183482567c7caf0 # v1.1.1


### PR DESCRIPTION
- Replace ubuntu 20.04 since the runner will be removed 2025-04-01.
- Use the last release of `icc` to be able to update the ubuntu runner.
- Use available gcc/clang versions in weekly CI runs (gcc-7 removed).
- Bump aminya/setup-cpp from 0.40.0 to 1.1.1

Weekly run looks fine:
https://github.com/Nordix/flatcc/actions/runs/13786429513