### PR TITLE
Sync flatcc_verify_typed_buffer_header_with_size parameter name vs. definition

### DIFF
--- a/include/flatcc/flatcc_verifier.h
+++ b/include/flatcc/flatcc_verifier.h
@@ -209,7 +209,7 @@ int flatcc_verify_typed_buffer_header(const void *buf, size_t bufsiz, flatbuffer
  */
 int flatcc_verify_buffer_header_with_size(const void *buf, size_t *bufsiz, const char *fid);
 
-int flatcc_verify_typed_buffer_header_with_size(const void *buf, size_t *bufsiz, flatbuffers_thash_t type_hash);
+int flatcc_verify_typed_buffer_header_with_size(const void *buf, size_t *bufsiz, flatbuffers_thash_t thash);
 
 /*
  * The following functions are typically called by a generated table


### PR DESCRIPTION
https://github.com/dvidelabs/flatcc/blob/b50e43dd1269b91203be8b5b185923d841c93e70/src/runtime/verifier.c#L511

As flagged by `clang-tidy`:

https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html

---

The alternative is to change the name in the definition, which requires a bigger diff. The function is short enough that there's not much difference either way, though.