### PR TITLE
fix(grisu3): GCC15 Complaining about non-null terminated string

### DIFF
--- a/external/grisu3/grisu3_print.h
+++ b/external/grisu3/grisu3_print.h
@@ -183,7 +183,7 @@ static int grisu3_i_to_str(int val, char *str)
 
 static int grisu3_print_nan(uint64_t v, char *dst)
 {
-    static char hexdigits[16] = "0123456789ABCDEF";
+    static char hexdigits[] = "0123456789ABCDEF";
     int i = 0;
 
     dst[0] = 'N';

--- a/include/flatcc/portable/grisu3_print.h
+++ b/include/flatcc/portable/grisu3_print.h
@@ -183,7 +183,7 @@ static int grisu3_i_to_str(int val, char *str)
 
 static int grisu3_print_nan(uint64_t v, char *dst)
 {
-    static char hexdigits[16] = "0123456789ABCDEF";
+    static char hexdigits[] = "0123456789ABCDEF";
     int i = 0;
 
     dst[0] = 'N';


### PR DESCRIPTION
GCC15 started issuing a warning for non-null terminated string initiaziotions (`unterminated-string-initialization`).  
Avoiding the error by letting the compiler append the NULL