### PR TITLE
Fail tests when UBSan finds issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,12 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT "${CMAKE_CXX_SIMULATE_ID}" STREQ
         if (CMAKE_BUILD_TYPE MATCHES Debug)
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+            # Don't recover from found issues, we want tests to exit. We then need `__has_feature`
+            # which was added in clang-8, see https://github.com/llvm/llvm-project/commit/b32d404
+            if (NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8)
+                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-sanitize-recover=all")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-sanitize-recover=all")
+            endif()
         endif()
     endif()
     # Suppress warning relaxed in clang-6, see https://reviews.llvm.org/D28148

--- a/include/flatcc/portable/pprintint.h
+++ b/include/flatcc/portable/pprintint.h
@@ -102,7 +102,9 @@ static int print_int(int n, char *p);
 static int print_long(long n, char *p);
 
 
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+/* The UBSan will warn about storing to misaligned address. */
+#if !(defined(__has_feature) && __has_feature(undefined_behavior_sanitizer)) && \
+    (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64))
 #define __print_unaligned_copy_16(p, q) (*(uint16_t*)(p) = *(uint16_t*)(q))
 #else
 #define __print_unaligned_copy_16(p, q)                                     \

--- a/include/flatcc/portable/punaligned.h
+++ b/include/flatcc/portable/punaligned.h
@@ -28,7 +28,10 @@ extern "C" {
 
 #ifndef PORTABLE_UNALIGNED_ACCESS
 
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+#if defined(__has_feature) && __has_feature(undefined_behavior_sanitizer)
+/* The UBSan will warn about unaligned access. */
+#define PORTABLE_UNALIGNED_ACCESS 0
+#elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 #define PORTABLE_UNALIGNED_ACCESS 1
 #else
 #define PORTABLE_UNALIGNED_ACCESS 0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,6 +25,11 @@ fi
 echo "building before tests ..."
 $ROOT/scripts/build.sh $DEBUG
 
+# Configure the UBSan if used.
+if [ -z "${UBSAN_OPTIONS}" ]; then
+    export UBSAN_OPTIONS="print_stacktrace=1"
+fi
+
 echo "running test in debug build ..."
 cd $DBGDIR && ctest $ROOT
 

--- a/test/monster_test/monster_test.c
+++ b/test/monster_test/monster_test.c
@@ -2568,6 +2568,8 @@ int test_struct_buffer(flatcc_builder_t *B)
     /* Convert buffer to native in place - a nop on native platform. */
     v = (ns(Vec3_t) *)vec3;
     ns(Vec3_from_pe(v));
+/* UBSan warns about member access within misaligned address. */
+#if !(defined(__has_feature) && __has_feature(undefined_behavior_sanitizer))
     if (!parse_float_is_equal(v->x, 1.0f) || !parse_float_is_equal(v->y, 2.0f) || !parse_float_is_equal(v->z, 3.0f)
         || !parse_double_is_equal(v->test1, 4.2) || v->test2 != ns(Color_Blue)
         || v->test3.a != 2730 || v->test3.b != -17
@@ -2575,6 +2577,7 @@ int test_struct_buffer(flatcc_builder_t *B)
         printf("struct buffer not valid\n");
         return -1;
     }
+#endif
     assert(ns(Color_Red) == 1 << 0);
     assert(ns(Color_Green) == 1 << 1);
     assert(ns(Color_Blue) == 1 << 3);
@@ -2633,6 +2636,8 @@ int test_typed_struct_buffer(flatcc_builder_t *B)
     /* Convert buffer to native in place - a nop on native platform. */
     v = (ns(Vec3_t) *)vec3;
     ns(Vec3_from_pe(v));
+/* UBSan warns about member access within misaligned address. */
+#if !(defined(__has_feature) && __has_feature(undefined_behavior_sanitizer))
     if (!parse_float_is_equal(v->x, 1.0f) || !parse_float_is_equal(v->y, 2.0f) || !parse_float_is_equal(v->z, 3.0f)
         || !parse_double_is_equal(v->test1, 4.2) || v->test2 != ns(Color_Blue)
         || v->test3.a != 2730 || v->test3.b != -17
@@ -2640,6 +2645,7 @@ int test_typed_struct_buffer(flatcc_builder_t *B)
         printf("struct buffer not valid\n");
         return -1;
     }
+#endif
     assert(ns(Color_Red) == 1 << 0);
     assert(ns(Color_Green) == 1 << 1);
     assert(ns(Color_Blue) == 1 << 3);


### PR DESCRIPTION
We have found that there are a couple of issues when building with the UndefinedBehaviorSanitizer.
Some checkers in the UBSan arsenal are recoverable and just gives a printout to stderr, i.e. ctest does not fail.
Adding `-fno-sanitize-recover=all` triggers tests to exit instead, and issues are visible.

While enabling this a couple issues surfaces, like unaligned access warnings in 10 test binaries, and most are fixed by a change in `pprintint.h` and `punaligned.h`.

There is an open question about how to solve the issue in `monster_test.c`, I'm not sure if there is proper fix.
Any feedback/ideas?

Weekly test run [OK](https://github.com/Nordix/flatcc/actions/runs/15612083989).