### PR TITLE
Fixup warning on GCC_VERSION: 15.1.1

### DIFF
--- a/include/flatcc/portable/grisu3_print.h
+++ b/include/flatcc/portable/grisu3_print.h
@@ -183,7 +183,7 @@ static int grisu3_i_to_str(int val, char *str)
 
 static int grisu3_print_nan(uint64_t v, char *dst)
 {
-    static char hexdigits[16] = "0123456789ABCDEF";
+    static char hexdigits[16] __attribute__((nonstring)) = "0123456789ABCDEF";
     int i = 0;
 
     dst[0] = 'N';


### PR DESCRIPTION
On a fairly recent arch, flatcc fails to compile due to a new warning in the portable printf implementation:

```[  2%] Building C object src/runtime/CMakeFiles/flatccrt.dir/json_printer.c.o
In file included from /home/jeff/projects/flatcc/include/flatcc/portable/pprintfp.h:17,
                 from /home/jeff/projects/flatcc/src/runtime/json_printer.c:26:
/home/jeff/projects/flatcc/include/flatcc/portable/grisu3_print.h: In function ‘grisu3_print_nan’:
/home/jeff/projects/flatcc/include/flatcc/portable/grisu3_print.h:186:33: error: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (17 chars into 16 available) [-Werror=unterminated-string-initialization]
  186 |     static char hexdigits[16] = "0123456789ABCDEF";
      |                                 ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [src/runtime/CMakeFiles/flatccrt.dir/build.make:149: src/runtime/CMakeFiles/flatccrt.dir/json_printer.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:152: src/runtime/CMakeFiles/flatccrt.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

This small attribute additional silences the warning.

Forked from 47af7e6, 6.15.2-arch1-1 x86-64 and gcc (GCC) 15.1.1 20250425.

(there's another issue with too-new cmake--cmake version 4.0.3-dirty triggers the minimum cmake version check, but the fix for that is less obvious/trivial)