### PR TITLE
cmake: Set minimum required version to 3.5 for CMake 4+ compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Ubuntu 14.04 (Trusty)
-cmake_minimum_required (VERSION 2.8.12.2)
+cmake_minimum_required (VERSION 3.5)
 # Centos 7
 #cmake_minimum_required (VERSION 2.8.11)
 #cmake_minimum_required (VERSION 2.8)

--- a/external/hash/CMakeLists.txt
+++ b/external/hash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5)
 
 project (HashTest)
 


### PR DESCRIPTION
Fix:

| CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
|
|
| -- Configuring incomplete, errors occurred!