### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
     name: macOS
     runs-on: macos-14
     steps:
-      - name: Prepare
-        run: |
-          brew install ninja
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build and run tests
         run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -204,7 +204,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [2019, 2022]
+        version: [2022, 2025]
     steps:
       - uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang-version: [5, 7, 9, 11, 13, 15, 17, 18, 19]
+        clang-version: [5, 7, 9, 11, 13, 15, 17, 19, 20]
     steps:
       - name: Setup Clang
         uses: aminya/setup-cpp@004edc19527a83d56cda032658aab55c5e2ed48f # v1.7.0

--- a/test/monster_test_cpp/CMakeLists.txt
+++ b/test/monster_test_cpp/CMakeLists.txt
@@ -1,6 +1,12 @@
 include(CTest)
 
 # Note: This re-uses the samples/monster fbs and .c file.
+# According to the C++ standard Section 6.9.3.1 of ISO/IEC 14882:2024
+# "an entity named main with C language linkage (in any namespace) is ill-formed"
+# Let's disable the warning from Clang that we include main() using extern "C".
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wno-main)
+endif()
 
 set(INC_DIR "${PROJECT_SOURCE_DIR}/include")
 # We use our own separate gen dir so we don't clash with the real monster sample.


### PR DESCRIPTION
- Remove [deprecated](https://github.com/actions/runner-images/issues/12045) Github runner `windows-2019` and add `windows-2025` in weekly CI.
- Don't install the already installed `ninja` on `macos` runners.
- Add `clang-20` to weekly CI and..
- Disable new warning when building `monster_test_cpp`.
```
      monster.c:294:5: warning: 'main' should not be 'extern "C"' [-Wmain]
      294 | int main(int argc, char *argv[])
          |     ^
``` 


[Weekly](https://github.com/Nordix/flatcc/actions/runs/16322137465) runs pass.
