### PR TITLE
Add gcc-15 and big-endian runs in weekly CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -91,6 +91,24 @@ jobs:
           scripts/initbuild.sh make-concurrent
           scripts/test.sh
 
+  gcc-15:
+    name: GCC 15
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:25.04 # Provides gcc-15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Prepare
+        run: |
+          apt update && apt-get install -y gcc-15 g++-15 cmake
+      - name: Build and run tests
+        env:
+          CC: gcc-15
+          CXX: g++-15
+        run: |
+          scripts/initbuild.sh make-concurrent
+          scripts/test.sh
+
   gcc-32bit:
     name: GCC 32bit
     runs-on: ubuntu-24.04

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -228,3 +228,19 @@ jobs:
           cmake --version
           scripts/initbuild.sh make-concurrent
           scripts/test.sh
+
+  big-endian:
+    name: Big-endian (s390x via QEMU)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+        with:
+          arch: s390x
+          distro: ubuntu24.04
+          install: |
+            apt-get update
+            apt-get install -y --no-install-recommends build-essential cmake
+          run: |
+            scripts/initbuild.sh make-concurrent
+            scripts/test.sh


### PR DESCRIPTION
- Add gcc-15 to weekly CI.
  Currently gcc-15 is only provided in ubuntu's `25.04`. 
  Mentioned in #338.

- Add a job to weekly CI that builds and runs on a big-endian platform (s390x via QEMU).

A run on [weekly](https://github.com/Nordix/flatcc/actions/runs/16467686523).