### PR TITLE
Update Windows Build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2352,12 +2352,13 @@ In PowerShell:
     cd flatcc
     mkdir build\MSVC
     cd build\MSVC
+	cmake --help # Lists generators to choose from
     cmake -G "Visual Studio 14 2015" ..\..
 
 Optionally also build from the command line (in build\MSVC):
 
-    cmake --build . --target --config Debug
-    cmake --build . --target --config Release
+    cmake --build . --config Debug
+    cmake --build . --config Release
 
 In Visual Studio:
 


### PR DESCRIPTION
Remove `--target` (results in an error)
Add hint to use `camke --help` to determine the correct generator