### PR TITLE
grisu3: make hexdigits size explicit for GCC 15

### DIFF
--- a/include/flatcc/portable/grisu3_print.h
+++ b/include/flatcc/portable/grisu3_print.h
@@ -183,7 +183,7 @@ static int grisu3_i_to_str(int val, char *str)
 
 static int grisu3_print_nan(uint64_t v, char *dst)
 {
-    static char hexdigits[] = "0123456789ABCDEF";
+    static char hexdigits[17] = "0123456789ABCDEF";
     int i = 0;
 
     dst[0] = 'N';


### PR DESCRIPTION
GCC 15 emits `-Wunterminated-string-initialization` for the `hexdigits` declaration in `grisu3`. In toolchains where warnings are treated as errors, this results in a build failure. This is reproducible in Zephyr and Executorch environments using GCC 15.

The literal contains 16 characters plus the terminating `\0`. Making the array size explicit avoids the diagnostic and makes the storage unambiguous:

`static char hexdigits[17] = "0123456789ABCDEF";`

This change:
	•	Explicitly accounts for the null terminator
	•	Resolves GCC 15 build failures when -Werror is enabled
	•	Introduces no functional change

Tested with GCC 15 in Zephyr based and Executorch based builds.