### PR TITLE
Fix handling of bare exponent input in lex()

### DIFF
--- a/external/lex/luthor.c
+++ b/external/lex/luthor.c
@@ -1393,7 +1393,9 @@ lex_c_octal_to_exponent_part:
                 if (++p != q && *p != '+' && *p != '-') {
                     --p;
                 }
-                while (++p != q && lex_isdigit(*p)) {
+                if (p != q) {
+                    while (++p != q && lex_isdigit(*p)) {
+                    }
                 }
             }
             if (d != p) {


### PR DESCRIPTION
Bare exponent input at the end of the buffer would cause heap buffer overreads.

Fixes https://github.com/dvidelabs/flatcc/issues/374.