### PR TITLE
Replace rewind() with fseek() for error handling

### DIFF
--- a/include/flatcc/support/readfile.h
+++ b/include/flatcc/support/readfile.h
@@ -32,7 +32,7 @@ static char *readfile(const char *filename, size_t max_size, size_t *size_out)
     if (max_size > 0 && size > max_size) {
         goto fail;
     }
-    rewind(fp);
+    if (fseek(fp, 0L, SEEK_SET)) goto fail;
     buf = (char *)malloc(size ? size : 1);
     if (!buf) {
         goto fail;

--- a/src/compiler/fileio.c
+++ b/src/compiler/fileio.c
@@ -197,7 +197,7 @@ char *fb_read_file(const char *filename, size_t max_size, size_t *size_out)
     if (max_size > 0 && size > max_size) {
         goto fail;
     }
-    rewind(fp);
+    if (fseek(fp, 0L, SEEK_SET)) goto fail;
     buf = malloc(size ? size : 1);
     if (!buf) {
         goto fail;


### PR DESCRIPTION
# PR: Replace rewind() with fseek() for error handling

## Summary

`rewind()` is equivalent to `(void)fseek(fp, 0L, SEEK_SET)` and silently discards any seek error. This replaces it with `fseek()` and checks the return value in `readfile.h` and `fileio.c` so that a failed seek propagates to the caller via the existing `fail` path.

## Changes

- `include/flatcc/support/readfile.h`: replace `rewind(fp)` with `if (fseek(fp, 0L, SEEK_SET)) goto fail;`
- `src/compiler/fileio.c`: same change

## Motivation

Static analysis (CWE-676) flags `rewind()` as a potentially dangerous function because it provides no way to detect errors. Both call sites already have a `fail` label with proper cleanup, so wiring in the error check is straightforward.

## Testing

Built and tested with CMake on Linux (gcc/clang). No behavioral change for the success path; the fail path now correctly triggers on seek errors.