### PR TITLE
coerce.c: fix int32/int16/int8 default-value overflow check reading wrong union member

### DIFF
--- a/src/compiler/coerce.c
+++ b/src/compiler/coerce.c
@@ -125,7 +125,7 @@ int fb_coerce_scalar_type(fb_parser_t *P, fb_symbol_t *sym, fb_scalar_type_t st,
             return 0;
         }
         if (value->type == vt_uint) {
-            if (value->i > INT32_MAX) {
+            if (value->u > INT32_MAX) {
                 error_sym(P, sym, "32-bit signed int overflow");
                 value->type = vt_invalid;
                 return -1;
@@ -147,7 +147,7 @@ int fb_coerce_scalar_type(fb_parser_t *P, fb_symbol_t *sym, fb_scalar_type_t st,
             return 0;
         }
         if (value->type == vt_uint) {
-            if (value->i > INT16_MAX) {
+            if (value->u > INT16_MAX) {
                 error_sym(P, sym, "16-bit signed short overflow");
                 value->type = vt_invalid;
                 return -1;
@@ -169,7 +169,7 @@ int fb_coerce_scalar_type(fb_parser_t *P, fb_symbol_t *sym, fb_scalar_type_t st,
             return 0;
         }
         if (value->type == vt_uint) {
-            if (value->i > INT8_MAX) {
+            if (value->u > INT8_MAX) {
                 error_sym(P, sym, "8-bit signed byte overflow");
                 value->type = vt_invalid;
                 return -1;


### PR DESCRIPTION
## Problem

`fb_coerce_scalar_type()` in `src/compiler/coerce.c` validates integer default values against the target scalar type's range. For the `fb_int`, `fb_short`, and `fb_byte` branches, when the parsed default literal is `vt_uint` (i.e. was lexed/stored as an unsigned value), the overflow check reads the wrong union member:

```c
if (value->type == vt_uint) {
    if (value->i > INT32_MAX) {   /* reads .i, but the value was stored via .u */
```

`fb_value_t` stores `i` (`int64_t`) and `u` (`uint64_t`) in a union sharing the same bytes. When a `vt_uint` literal's bit pattern has the high bit set (e.g. any value >= 2^63, or an unsigned literal originally >= INT64_MAX), reinterpreting it through the signed `.i` member produces a negative number, so `value->i > INT32_MAX` is false and the overflow check is silently bypassed.

This lets schemas with wildly out-of-range unsigned default values for signed `int32`/`int16`/`int8` fields compile without any diagnostic, baking garbage sign-flipped constants into the generated reader headers instead of failing with the intended `"N-bit signed ... overflow"` error.

The sibling branches for unsigned targets (`fb_uint`, `fb_ushort`, `fb_ubyte`) and `fb_long` already correctly compare against `.u` — this fix simply makes the three signed branches consistent with them.

## Reproduction

```
table T { x:int32 = 9223372036854775808; }   // 2^63
```
Before fix: compiles with exit 0, no error, and generates `INT32_C(-9223372036854775808)` in the reader header.

```
table T { x:int32 = 18446744073709551615; }  // UINT64_MAX
```
Before fix: compiles with exit 0, no error, and generates `INT32_C(-1)`.

After the fix, both correctly fail with `error: 'x': 32-bit signed int overflow` (exit 127), matching the existing behavior for smaller-magnitude overflow values like `x:int32 = 5000000000;`. Analogous constructed cases for `int16`/`int8` are fixed the same way.

Regression-checked: legitimate in-range positive/negative `int32`/`int16`/`int8` defaults plus an in-range `uint32` default still compile cleanly and produce the correct constants after the fix — no new false positives.

## Fix

3-line change: use `value->u` instead of `value->i` in the overflow comparisons for the `fb_int`, `fb_short`, and `fb_byte` cases, matching the pattern already used by `fb_uint`/`fb_ushort`/`fb_ubyte`/`fb_long`.
