### PR TITLE
Fix broken Weekly CI and modernize runner configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build and run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,11 @@ jobs:
 
   windows:
     name: Windows
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
-      - uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build and run tests
         run: |
           cmake .
-          msbuild FlatCC.sln /m /property:Configuration=Release
+          cmake --build . --config Release
           ctest -VV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   ubuntu-ninja-clang:
     name: Ubuntu (ninja, clang)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Prepare
         run: |
@@ -27,7 +27,7 @@ jobs:
 
   ubuntu-make-gcc:
     name: Ubuntu (make, gcc)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build and run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install ninja-build
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         env:
           CC: clang
@@ -29,7 +29,7 @@ jobs:
     name: Ubuntu (make, gcc)
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         env:
           CC: gcc
@@ -42,7 +42,7 @@ jobs:
     name: macOS
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           scripts/test.sh
@@ -51,7 +51,7 @@ jobs:
     name: Windows
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           cmake .

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -32,7 +32,7 @@ jobs:
 
   clang-32bit:
     name: Clang 32bit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Prepare
         run: |
@@ -93,14 +93,13 @@ jobs:
 
   gcc-15:
     name: GCC 15
-    runs-on: ubuntu-24.04
-    container:
-      image: ubuntu:25.04 # Provides gcc-15
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Prepare
         run: |
-          apt update && apt-get install -y gcc-15 g++-15 cmake
+          sudo apt update
+          sudo apt install gcc-15 g++-15
       - name: Build and run tests
         env:
           CC: gcc-15
@@ -111,7 +110,7 @@ jobs:
 
   gcc-32bit:
     name: GCC 32bit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Prepare
         run: |
@@ -233,7 +232,7 @@ jobs:
 
   debian:
     name: Debian ${{ matrix.version }} "${{ matrix.name }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -240,8 +240,8 @@ jobs:
         include:
           - version: 12
             name: Bookworm
-          - version: 11
-            name: Bullseye
+          - version: 13
+            name: Trixie
     container:
       image: debian:${{ matrix.version }}
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,10 +21,10 @@ jobs:
         clang-version: [5, 7, 9, 11, 13, 15, 17, 19, 21]
     steps:
       - name: Setup Clang
-        uses: aminya/setup-cpp@a276e6e3d1db9160db5edc458e99a30d3b109949 # v1.7.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           llvm: ${{ matrix.clang-version }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -38,7 +38,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gcc-multilib g++-multilib
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         env:
           CC: clang
@@ -64,7 +64,7 @@ jobs:
           sudo dpkg -i ./cpp-4.4_4.4.7-8ubuntu1_amd64.deb
           sudo dpkg -i ./gcc-4.4_4.4.7-8ubuntu1_amd64.deb
           sudo dpkg -i ./libstdc++6-4.4-dev_4.4.7-8ubuntu1_amd64.deb ./g++-4.4_4.4.7-8ubuntu1_amd64.deb
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         env:
           CC: gcc-4.4
@@ -82,10 +82,10 @@ jobs:
         gcc-version: [9, 11, 13, 14]
     steps:
       - name: Setup GCC
-        uses: aminya/setup-cpp@a276e6e3d1db9160db5edc458e99a30d3b109949 # v1.7.1
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:
           gcc: ${{ matrix.gcc-version }}
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -95,7 +95,7 @@ jobs:
     name: GCC 15
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prepare
         run: |
           sudo apt update
@@ -116,7 +116,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gcc-multilib g++-multilib
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-32bit
@@ -142,7 +142,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         env:
           CC: ${{ matrix.compiler }}
@@ -155,7 +155,7 @@ jobs:
     name: macOS Clang
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -165,7 +165,7 @@ jobs:
     name: macOS Clang (x86)
     runs-on: macos-26-intel
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           scripts/initbuild.sh make-concurrent
@@ -179,7 +179,7 @@ jobs:
       matrix:
         gcc-version: [13, 14, 15] # Github supports the 3 latest major versions.
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prepare
         run: |
           # Install gcc if not already available.
@@ -201,7 +201,7 @@ jobs:
       matrix:
         gcc-version: [13, 14, 15] # Github supports the 3 latest major versions.
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prepare
         run: |
           # Install gcc if not already available.
@@ -223,7 +223,7 @@ jobs:
       matrix:
         version: [2022, 2025, 11-arm]
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           cmake .
@@ -244,7 +244,7 @@ jobs:
     container:
       image: debian:${{ matrix.version }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prepare
         run: |
           apt update && apt-get install -y build-essential cmake
@@ -258,10 +258,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
           cmake-version: 3.16
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build and run tests
         run: |
           cmake --version
@@ -272,8 +272,8 @@ jobs:
     name: Big-endian (s390x via QEMU)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
         with:
           arch: s390x
           distro: ubuntu24.04

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -154,7 +154,7 @@ jobs:
 
   macos-clang:
     name: macOS Clang
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build and run tests

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -20,6 +20,12 @@ jobs:
       matrix:
         clang-version: [5, 7, 9, 11, 13]
     steps:
+      - name: Install libtinfo5
+        run: |
+          # Old Clang binaries need libtinfo5 which is no longer in Ubuntu 24.04 repos.
+          # setup-cpp's fallback download from Launchpad is unreliable, so we install it directly.
+          wget -q http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb
+          sudo dpkg -i libtinfo5_6.3-2_amd64.deb
       - name: Setup Clang
         uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
         with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -222,14 +222,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [2022, 2025]
+        version: [2022, 2025, 11-arm]
     steps:
-      - uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build and run tests
         run: |
           cmake .
-          msbuild FlatCC.sln /m /property:Configuration=Release
+          cmake --build . --config Release
           ctest -VV
 
   debian:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,13 +12,31 @@ permissions:
   contents: read
 
 jobs:
-  clang:
+  clang-old:
     name: Clang ${{ matrix.clang-version }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        clang-version: [5, 7, 9, 11, 13, 15, 17, 19, 21]
+        clang-version: [5, 7, 9, 11, 13]
+    steps:
+      - name: Setup Clang
+        uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1
+        with:
+          llvm: ${{ matrix.clang-version }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build and run tests
+        run: |
+          scripts/initbuild.sh make-concurrent
+          scripts/test.sh
+
+  clang:
+    name: Clang ${{ matrix.clang-version }}
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        clang-version: [15, 17, 19, 21, 22]
     steps:
       - name: Setup Clang
         uses: aminya/setup-cpp@8170d66c458f4a045220b7b0966c10940bb2a15d # v1.8.1


### PR DESCRIPTION
- Fix Windows build failure: replace msbuild `cmake --build` to handle VS 2026 on `windows-2025` runner
  Remove action `microsoft/setup-msbuild` since its not needed when we let CMake build.
- Add `Windows Visual Studio 11-arm`
- Replace retired `macos-14` runner with `macos-26`
- Update Debian matrix: drop EOL `Bullseye` (11), add `Trixie` (13)
- Upgrade Ubuntu runner to 26.04 for modern toolchain jobs (keep 24.04/22.04 for legacy compilers)
- Add Clang 22 to weekly matrix
- Bump action versions: checkout v7.0.1, setup-cpp v1.8.1, actions-setup-cmake v2.2.0, run-on-arch-action v3.1.0
  This replaces the dependabot PRs.

The `aminya/setup-cpp` action still gives annotations/warnings when retrying to add apt keys, but it succeeds to install the compilers. (Weekly run: https://github.com/Nordix/flatcc/actions/runs/30353387666)